### PR TITLE
[2] Aromatic fragments

### DIFF
--- a/cgsmiles/graph_utils.py
+++ b/cgsmiles/graph_utils.py
@@ -49,6 +49,7 @@ def merge_graphs(source_graph, target_graph, max_node=None):
     for node1, node2 in target_graph.edges:
         if correspondence[node1] != correspondence[node2]:
             attrs = target_graph.edges[(node1, node2)]
+            print(attrs)
             source_graph.add_edge(correspondence[node1], correspondence[node2], **attrs)
 
     return correspondence

--- a/cgsmiles/pysmiles_utils.py
+++ b/cgsmiles/pysmiles_utils.py
@@ -3,6 +3,49 @@ import pysmiles
 VALENCES = pysmiles.smiles_helper.VALENCES
 VALENCES.update({"H": (1,)})
 
+def _smiles_node_iter(smiles_str):
+    """
+    Iterate over all nodes in SMILES string and return
+    the index of the node.
+    """
+    organic_subset = 'B C N O P S F Cl Br I * b c n o s p'.split()
+    batom = False
+    for idx, node in enumerate(smiles_str):
+        if node == '[':
+            batom = True
+            start = idx
+
+        if node == ']' and batom:
+            stop = idx+1
+            batom = False
+            yield start, stop
+
+        if node in organic_subset and not batom:
+            yield idx, idx + 1
+
+def strip_aromatic_nodes(smiles_str):
+    """
+    Find all aromatic nodes and change them to lower
+    case but keep a mapping of changed nodes.
+    """
+    aromatic_shorthand = 'b c n o s p'.split()
+    aromatic_atoms = {}
+    nodes_iter = _smiles_node_iter(smiles_str)
+    cleaned_str = ""
+    prev_stop = 0
+    for idx, (start, stop) in enumerate(nodes_iter):
+        if smiles_str[start] in aromatic_shorthand:
+            aromatic_atoms[idx] = True
+            cleaned_str += smiles_str[prev_stop:start] + smiles_str[start:stop].upper()
+        else:
+            aromatic_atoms[idx] = False
+            cleaned_str += smiles_str[prev_stop:stop]
+        prev_stop = stop
+
+    cleaned_str +=  smiles_str[prev_stop:]
+    return aromatic_atoms, cleaned_str
+
+
 def rebuild_h_atoms(mol_graph, keep_bonding=False):
     """
     Helper function which add hydrogen atoms to the molecule graph.


### PR DESCRIPTION
Pysmiles does not allow partial aromatic fragments (for good reason) yet we still want to do them. Thus here we have a workaround. If two atoms are marked as aromatic we simply convert them to regular elements and later change it back. It's stupid but works.

Example Case Martini3 p-cresol:

```
cgsmiles_str = "{[#TN6]1[#TC5][#TC5A][#TC5]1}.{#TN6=[$][$]cO,#TC5=[$]cc[$],#TC5A=[$][$]cc}"
```

The aromatic ring is fragmented into four fragments.