### PR TITLE
Use raw strings in `PATTERNS`

### DIFF
--- a/cgsmiles/read_cgsmiles.py
+++ b/cgsmiles/read_cgsmiles.py
@@ -3,9 +3,9 @@ import re
 import numpy as np
 import networkx as nx
 
-PATTERNS = {"bond_anchor": "\[\$.*?\]",
-            "place_holder": "\[\#.*?\]",
-            "annotation": "\|.*?\|",
+PATTERNS = {"bond_anchor": r"\[\$.*?\]",
+            "place_holder": r"\[\#.*?\]",
+            "annotation": r"\|.*?\|",
             "fragment": r'#(\w+)=((?:\[.*?\]|[^,\[\]]+)*)',
             "seq_pattern": r'\{([^}]*)\}(?:\.\{([^}]*)\})?'}
 

--- a/cgsmiles/resolve.py
+++ b/cgsmiles/resolve.py
@@ -180,7 +180,7 @@ class MoleculeResolver:
  
                 # bonding descriptors are assumed to have bonding order 1
                 # unless they are specifically annotated
-                order = re.findall("[-+]?[.]?[\d]+(?:,\d\d\d)*[\.]?\d*(?:[eE][-+]?\d+)?", bonding[0])
+                order = re.findall(r"[-+]?[.]?[\d]+(?:,\d\d\d)*[\.]?\d*(?:[eE][-+]?\d+)?", bonding[0])
                 if not order:
                     order = 1
                 else:


### PR DESCRIPTION
Currently, I'd get these SyntaxWarnings:

```
/Users/alessandri/CGsmiles/cgsmiles/read_cgsmiles.py:6: SyntaxWarning: invalid escape sequence '\['
  PATTERNS = {"bond_anchor": "\[\$.*?\]",
/Users/alessandri/CGsmiles/cgsmiles/read_cgsmiles.py:7: SyntaxWarning: invalid escape sequence '\['
  "place_holder": "\[\#.*?\]",
/Users/alessandri/CGsmiles/cgsmiles/read_cgsmiles.py:8: SyntaxWarning: invalid escape sequence '\|'
  "annotation": "\|.*?\|",
/Users/alessandri/CGsmiles/cgsmiles/resolve.py:183: SyntaxWarning: invalid escape sequence '\d'
  order = re.findall("[-+]?[.]?[\d]+(?:,\d\d\d)*[\.]?\d*(?:[eE][-+]?\d+)?", bonding[0])
 ```
 
Making those raw strings fixes this.