### PR TITLE
[4] Bug fix multlett atom

### DIFF
--- a/cgsmiles/read_fragments.py
+++ b/cgsmiles/read_fragments.py
@@ -14,6 +14,12 @@ def mark_aromatic_edges(graph):
             graph.edges[edge]["order"] = 1.5
     return graph
 
+def _adjust_aromatic_hcount(graph, aromatic_nodes):
+    for node, aromatic in aromatic_nodes.items():
+        if aromatic:
+            graph.nodes[node]['hcount'] = graph.nodes[node]['hcount'] - 1
+    return graph
+
 def strip_bonding_descriptors(fragment_string):
     """
     Processes a CGBigSmile fragment string by
@@ -121,6 +127,8 @@ def fragment_iter(fragment_str, all_atom=True):
                 nx.set_node_attributes(mol_graph, arom_nodes, "aromatic")
                 # set the bond order for the aromatic edges
                 mol_graph = mark_aromatic_edges(mol_graph)
+                # for all aromatic edges reduce hcount by 1
+                _adjust_aromatic_hcount(mol_graph, arom_nodes)
 
             nx.set_node_attributes(mol_graph, bonding_descrpt, 'bonding')
         # we deal with a CG resolution graph

--- a/cgsmiles/resolve.py
+++ b/cgsmiles/resolve.py
@@ -227,7 +227,7 @@ class MoleculeResolver:
 
         # contract atoms with squash descriptors
         self.squash_atoms()
-
+        print(self.molecule.edges(data=True))
         # rebuild hydrogen in all-atom case
         if self.all_atom:
             mark_aromatic_edges(self.molecule)

--- a/cgsmiles/tests/test_cgsmile_parsing.py
+++ b/cgsmiles/tests/test_cgsmile_parsing.py
@@ -158,6 +158,14 @@ def test_read_cgsmiles(smile, nodes, edges, orders):
                         ("[$]COC[$]",
                          "COC",
                         {0: ["$"], 2: ["$"]}),
+                        # smiple bonding multiletter atom
+                        ("Clc[$]c[$]",
+                         "Clcc",
+                        {1: ["$"], 2: ["$"]}),
+                        # smiple bonding multiletter atom
+                        ("Clc[$]c[$]",
+                         "Clcc",
+                        {1: ["$"], 2: ["$"]}),
                         # simple symmetric but with explicit hydrogen
                         ("[$][CH2]O[CH2][$]",
                          "[CH2]O[CH2]",
@@ -185,6 +193,7 @@ def test_read_cgsmiles(smile, nodes, edges, orders):
 ))
 def test_strip_bonding_descriptors(big_smile, smile, bonding):
     new_smile, new_bonding = strip_bonding_descriptors(big_smile)
+    print(new_smile, new_bonding)
     assert new_smile == smile
     assert new_bonding == bonding
 

--- a/cgsmiles/tests/test_molecule_resolve.py
+++ b/cgsmiles/tests/test_molecule_resolve.py
@@ -158,6 +158,14 @@ def test_generate_edge(bonds_source, bonds_target, edge, btypes):
                         [(0, 2), (0, 3), (2, 4), (2, 5),
                          (3, 6), (3, 7), (2, 8), (3, 9),
                          (8, 9), (9, 12), (9, 13), (8, 10), (8, 11)]),
+                        # Toluene like test case with squash operator and aromaticity
+                        ("{[#SC3]1[#TC5][#TC5]1}.{#SC3=Cc(c[!])c[!],#TC5=[!]ccc[!]}",
+                        [('SC3', 'C C H H H C H C H'),
+                         ('TC5', 'C H C H C H')],
+                        'C C H H H C H C H C H C H C H',
+                        [(0, 1), (0, 2), (0, 3), (0, 4), (1, 5),
+                         (1, 7), (5, 9), (5, 6), (7, 13), (7, 8),
+                         (9, 11), (9, 10), (11, 13), (11, 12), (13, 14)]),
 ))
 def test_all_atom_resolve_molecule(smile, ref_frags, elements, ref_edges):
     meta_mol, molecule = MoleculeResolver(smile).resolve()


### PR DESCRIPTION
When having multi-letter atoms such as Cl, Br etc. and they are not enclosed in square brackets the bonding descriptor annotation is off by 1 