### PR TITLE
Weights

### DIFF
--- a/cgsmiles/graph_utils.py
+++ b/cgsmiles/graph_utils.py
@@ -164,8 +164,11 @@ def set_atom_names_atomistic(molecule, meta_graph=None):
     fraglist = defaultdict(list)
     if meta_graph:
         for meta_node in meta_graph.nodes:
-            fraggraph = meta_graph.nodes[meta_node]['graph']
-            fraglist[meta_node] += list(fraggraph.nodes)
+            # to catch virtual side nodes that do not have a representation
+            # in the atomsitic structure
+            fraggraph = meta_graph.nodes[meta_node].get('graph', None)
+            if fraggraph:
+                fraglist[meta_node] += list(fraggraph.nodes)
     else:
         node_to_fragid = nx.get_node_attributes(molecule, 'fragid')
         for node, fragids in node_to_fragid.items():

--- a/cgsmiles/pysmiles_utils.py
+++ b/cgsmiles/pysmiles_utils.py
@@ -83,6 +83,11 @@ def rebuild_h_atoms(mol_graph, keep_bonding=False):
             ref_node = next(mol_graph.neighbors(node))
             mol_graph.nodes[node]["fragid"] = mol_graph.nodes[ref_node]["fragid"]
             mol_graph.nodes[node]["fragname"] = mol_graph.nodes[ref_node]["fragname"]
+        if mol_graph.nodes[node].get("element", "*") == "H":
+            # make sure the weights are copied for implicit h-atoms
+            anchor = list(mol_graph.neighbors(node))[0]
+            weight = mol_graph.nodes[anchor].get("weight", 1)
+            mol_graph.nodes[node]["weight"] = weight
 
 def annotate_ez_isomers(molecule):
     """

--- a/cgsmiles/read_cgsmiles.py
+++ b/cgsmiles/read_cgsmiles.py
@@ -53,10 +53,6 @@ def _expand_branch(mol_graph, current, anchor, recipe):
     prev_node = anchor
     return mol_graph, current, prev_node
 
-def _get_percent(pattern, stop):
-    end_num = _find_next_character(pattern, ['[', ')', '(', '}'], stop)
-    return pattern[stop+1:end_num]
-
 def read_cgsmiles(pattern):
     """
     Generate a :class:`nx.Graph` from a pattern string according to the
@@ -133,6 +129,10 @@ def read_cgsmiles(pattern):
     cycle_edges = []
     # each element in the for loop matches a pattern
     # '[' + '#' + some alphanumeric name + ']'
+    symbol_to_order = {".": 0, "=": 2, "-": 1, "#": 3, "$": 4}
+    default_bond_order = 1
+    bond_order = None
+    prev_bond_order = None
     for match in re.finditer(PATTERNS['place_holder'], pattern):
         start, stop = match.span()
         # we start a new branch when the residue is preceded by '('
@@ -146,27 +146,53 @@ def read_cgsmiles(pattern):
 
         # here we check if the atom is followed by a cycle marker
         # in this case we have an open cycle and close it
-        for token in pattern[stop:]:
-            # we close a cycle
-            if token.isdigit() and token in cycle:
-                cycle_edges.append((current, cycle[token]))
-                del cycle[token]
-            # we open a cycle
-            elif token.isdigit():
-                cycle[token] = current
-            # we found a ring indicator
-            elif token == "%":
-                ring_marker = _get_percent(pattern, stop)
-                # we close the ring
+        ring_marker = ""
+        multi_ring = False
+        ring_bond_order = default_bond_order
+        for rdx, token in enumerate(pattern[stop:]):
+            if multi_ring and not token.isdigit():
                 if ring_marker in cycle:
-                    cycle_edges.append((current, cycle[ring_marker]))
+                    cycle_edges.append((current,
+                                        cycle[ring_marker][0],
+                                        cycle[ring_marker][1]))
                     del cycle[ring_marker]
-                    break
-                # we open a new ring
-                cycle[_get_percent(pattern, stop)] = current
-                break
+                else:
+                    cycle[ring_marker] = [current, ring_bond_order]
+                multi_ring = False
+                ring_marker = ""
+                ring_bond_order = default_bond_order
+
+            # we open a new multi ring
+            if token == "%":
+                multi_ring = True
+                ring_marker = '%'
+            # we open a ring or close
+            elif token.isdigit():
+                ring_marker += token
+                if not multi_ring:
+                    # we have a single digit marker and it is in
+                    # cycle so we close it
+                    if ring_marker in cycle:
+                        cycle_edges.append((current,
+                                            cycle[ring_marker][0],
+                                            cycle[ring_marker][1]))
+                        del cycle[ring_marker]
+                    # the marker is not in cycle so we update cycles
+                    else:
+                        cycle[ring_marker] = [current, ring_bond_order]
+                    ring_marker = ""
+                    ring_bond_order = default_bond_order
+            # we found bond_order
+            elif token in symbol_to_order:
+                ring_bond_order = symbol_to_order[token]
             else:
                 break
+
+        # check if there is a bond-order following the node
+        if stop < len(pattern) and pattern[stop+rdx-1] in '- + . = # $':
+            bond_order = symbol_to_order[pattern[stop+rdx-1]]
+        else:
+            bond_order = default_bond_order
 
         # here we check if the atom is followed by a expansion character '|'
         # as in ... [#PEO]|
@@ -197,16 +223,19 @@ def read_cgsmiles(pattern):
             mol_graph.add_node(current, fragname=fragname)
 
             if prev_node is not None:
-                mol_graph.add_edge(prev_node, current, order=1)
+                mol_graph.add_edge(prev_node, current, order=prev_bond_order)
+
+            prev_bond_order = bond_order
 
             # here we have a double edge
             for cycle_edge in cycle_edges:
                 if cycle_edge in mol_graph.edges:
-                    mol_graph.edges[cycle_edge]["order"] += 1
-                else:
-                    mol_graph.add_edge(cycle_edge[0],
-                                       cycle_edge[1],
-                                       order=1)
+                    msg=("You define two edges between the same node."
+                         "Use bond order symbols instead.")
+                    raise SyntaxError(msg)
+                mol_graph.add_edge(cycle_edge[0],
+                                   cycle_edge[1],
+                                   order=cycle_edge[2])
 
             prev_node = current
             current += 1

--- a/cgsmiles/resolve.py
+++ b/cgsmiles/resolve.py
@@ -238,6 +238,12 @@ class MoleculeResolver:
             a dict of fragment graphs
         """
         for meta_node in self.meta_graph.nodes:
+            neighbors = self.meta_graph.neighbors(meta_node)
+            edge_orders = [self.meta_graph.edges[(meta_node, ndx)]['order'] for ndx in neighbors]
+            # we are dealing with a virtual node that has no projection to the
+            # next resolution level
+            if edge_orders and all([order == 0 for order in edge_orders]):
+                continue
             fragname = self.meta_graph.nodes[meta_node]['fragname']
             fragment = fragment_dict[fragname]
             correspondence = merge_graphs(self.molecule, fragment)
@@ -278,7 +284,10 @@ class MoleculeResolver:
             if the high resolution level graph has all-atom resolution
             default: False
         """
-        for prev_node, node in self.meta_graph.edges:
+        import random
+        edges = list(self.meta_graph.edges)
+        #random.shuffle(edges)
+        for prev_node, node in edges:
             for _ in range(0, self.meta_graph.edges[(prev_node, node)]["order"]):
                 prev_graph = self.meta_graph.nodes[prev_node]['graph']
                 node_graph = self.meta_graph.nodes[node]['graph']

--- a/cgsmiles/sample.py
+++ b/cgsmiles/sample.py
@@ -59,7 +59,7 @@ class MoleculeSampler:
     descriptor is used to highlight the fact that the probabilistic behaviour is driven
     by the bonding descriptors.
 
-     The sampler features a two level connectivity determination. First using the
+    The sampler features a two level connectivity determination. First using the
     `polymer_reactivities` an open bonding descriptor from the growing polymer
     molecule is selected according to the probabilities provided. Subsequently,
     a fragment is randomly chosen that has a matching complementary bonding

--- a/cgsmiles/tests/test_cgsmile_parsing.py
+++ b/cgsmiles/tests/test_cgsmile_parsing.py
@@ -191,6 +191,21 @@ def test_read_cgsmiles(smile, nodes, edges, orders):
                         None,
                         None,
                         None),
+                        # smiple symmetric bonding with weigth
+                        ("[$]C[O;0.5]C[$]",
+                         "C[O]C",
+                        {0: ["$1"], 2: ["$1"]},
+                        None,
+                        None,
+                        {1: 0.5}),
+                        # smiple symmetric bonding with weigth
+                        # using cgsmiles string
+                        ("[$][#TC4][#OT1;0.5][#CD1][$]",
+                         "[#TC4][#OT1][#CD1]",
+                        {0: ["$1"], 2: ["$1"]},
+                        None,
+                        None,
+                        {1: 0.5}),
                         # smiple symmetric bonding with more than one name
                         ("[$1A]COC[$1A]",
                          "COC",
@@ -284,13 +299,19 @@ def test_read_cgsmiles(smile, nodes, edges, orders):
                         None),
 ))
 def test_strip_bonding_descriptors(big_smile, smile, bonding, rs, ez, weights):
-    new_smile, new_bonding, rs_isomers, ez_isomers, weights = strip_bonding_descriptors(big_smile)
+    new_smile, new_bonding, rs_isomers, ez_isomers, weights_out = strip_bonding_descriptors(big_smile)
     assert new_smile == smile
     assert new_bonding == bonding
     if rs:
         assert rs == rs_isomers
     if ez:
         assert ez == ez_isomers
+    # here we check that the weights are correctly
+    # set for nodes with weights; the default is
+    # checked in another test
+    if weights:
+        for node, weight in weights.items():
+            assert weights_out[node] == weight
 
 @pytest.mark.parametrize('fragment_str, nodes, edges',(
                         # single fragment

--- a/cgsmiles/tests/test_cgsmile_parsing.py
+++ b/cgsmiles/tests/test_cgsmile_parsing.py
@@ -10,7 +10,7 @@ from cgsmiles.read_fragments import strip_bonding_descriptors, fragment_iter
                         [(0, 1), (1, 2)],
                         [1, 1]),
                         # smiple linear sequenece with multi-edge
-                        ("{[#PMA]1[#PEO]1}",
+                        ("{[#PMA]=[#PEO]}",
                         ["PMA", "PEO"],
                         [(0, 1)],
                         [2]),
@@ -34,6 +34,36 @@ from cgsmiles.read_fragments import strip_bonding_descriptors, fragment_iter
                         ["PMA", "PEO", "PMA"],
                         [(0, 1), (1, 2), (0, 2)],
                         [1, 1, 1]),
+                        # smiple cycle sequence bond order to next
+                        ("{[#PMA]1=[#PEO][#PMA]1}",
+                        ["PMA", "PEO", "PMA"],
+                        [(0, 1), (1, 2), (0, 2)],
+                        [2, 1, 1]),
+                        # smiple cycle sequence bond order in cycle
+                        ("{[#PMA]=1[#PEO][#PMA]1}",
+                        ["PMA", "PEO", "PMA"],
+                        [(0, 1), (1, 2), (0, 2)],
+                        [1, 1, 2]),
+                        # smiple cycle sequence two bond orders
+                        ("{[#PMA].1=[#PEO][#PMA]1}",
+                        ["PMA", "PEO", "PMA"],
+                        [(0, 1), (1, 2), (0, 2)],
+                        [2, 1, 0]),
+                        # smiple cycle sequence with % bond order
+                        ("{[#PMA]=%123[#PEO][#PMA]%123}",
+                        ["PMA", "PEO", "PMA"],
+                        [(0, 1), (1, 2), (0, 2)],
+                        [1, 1, 2]),
+                        # smiple cycle sequence with % bond order next
+                        ("{[#PMA]%123=[#PEO][#PMA]%123}",
+                        ["PMA", "PEO", "PMA"],
+                        [(0, 1), (1, 2), (0, 2)],
+                        [2, 1, 1]),
+                        # smiple cycle sequence with % two bond orders
+                        ("{[#PMA]=%123.[#PEO][#PMA]%123}",
+                        ["PMA", "PEO", "PMA"],
+                        [(0, 1), (1, 2), (0, 2)],
+                        [0, 1, 2]),
                         # smiple cycle sequence with %
                         ("{[#PMA]%123[#PEO][#PMA]%123}",
                         ["PMA", "PEO", "PMA"],
@@ -57,7 +87,7 @@ from cgsmiles.read_fragments import strip_bonding_descriptors, fragment_iter
                      #  [1, 1, 1, 1, 1, 1, 1, 1]),
                         # smiple linear sequenece with multi-edge
                         # in cycle
-                        ("{[#PMA]12[#PMA][#PMA][#PEO]12}",
+                        ("{[#PMA]=1[#PMA][#PMA][#PEO]1}",
                         ["PMA", "PMA", "PMA", "PEO"],
                         [(0, 1), (1, 2), (2, 3), (0, 3)],
                         [1, 1, 1, 2]),

--- a/cgsmiles/tests/test_molecule_resolve.py
+++ b/cgsmiles/tests/test_molecule_resolve.py
@@ -40,7 +40,7 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
     assert new_btypes == btypes
 
 
-@pytest.mark.parametrize('smile, ref_frags, elements, ref_edges, chiral, ez',(
+@pytest.mark.parametrize('smile, ref_frags, elements, ref_edges, chiral, ez, weights',(
                         # smiple linear seqeunce
                         ("{[#OHter][#PEO]|2[#OHter]}.{#PEO=[$]COC[$],#OHter=[$][O]}",
                         #           0 1             2 3 4 5 6 7 8
@@ -51,7 +51,7 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                         [(0, 1), (0, 2), (2, 3), (3, 4), (2, 5), (2, 6), (4, 7),
                          (4, 8), (4, 9), (9, 10), (10, 11), (9, 12), (9, 13),
                          (11, 14), (11, 15), (11, 16), (16, 17)],
-                        {}, {}),
+                        {}, {}, {}),
                         # smiple linear seqeunce with bond-order in link
                         ("{[#TC1][#TC4][#TC1]}.{#TC1=[$1]=CC=[$2],#TC4=[$1]=CC=[$2]}",
                         #         0 1 2 3 4 5            6 7 8 9
@@ -61,7 +61,7 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                         'C C H H H H C C H H C C H H H H',
                         [(0, 1), (0, 2), (1, 3), (1, 4), (1, 5), (0, 6), (6, 7),
                          (6, 8), (7, 9), (7, 11), (10, 11), (10, 12), (10, 13),
-                         (10, 14), (11, 15)], {}, {}),
+                         (10, 14), (11, 15)], {}, {}, {}),
                         # smiple linear seqeunce unconsumed bonding descrpt
                         ("{[#OHter][#PEO]|2[#OHter]}.{#PEO=[$]CO[>]C[$],#OHter=[$][O]}",
                         #           0 1             2 3 4 5 6 7 8
@@ -71,7 +71,7 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                         'O H C O C H H H H C O C H H H H O H',
                         [(0, 1), (0, 2), (2, 3), (3, 4), (2, 5), (2, 6), (4, 7),
                          (4, 8), (4, 9), (9, 10), (10, 11), (9, 12), (9, 13),
-                         (11, 14), (11, 15), (11, 16), (16, 17)], {}, {}),
+                         (11, 14), (11, 15), (11, 16), (16, 17)], {}, {}, {}),
                         # smiple linear seqeunce with ionic bond
                         ("{[#OHter][#PEO]|2[#OHter]}.{#PEO=[$]COC[$],#OHter=[$][O-].[Na+]}",
                         #           0 1             2 3 4 5 6 7 8
@@ -81,7 +81,7 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                         'O Na C O C H H H H C O C H H H H O Na',
                         [(0, 1), (0, 2), (2, 3), (3, 4), (2, 5), (2, 6), (4, 7),
                          (4, 8), (4, 9), (9, 10), (10, 11), (9, 12), (9, 13),
-                         (11, 14), (11, 15), (11, 16), (16, 17)], {}, {}),
+                         (11, 14), (11, 15), (11, 16), (16, 17)], {}, {}, {}),
                         # smiple linear seqeunce with ionic ending
                         ("{[#OH][#PEO]|2[#ON]}.{#PEO=[$]COC[$],#OH=[$]O,#ON=[$][O-]}",
                         #           0 1             2 3 4 5 6 7 8
@@ -91,7 +91,7 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                         'O H C O C H H H H C O C H H H H O',
                         [(0, 1), (0, 2), (2, 3), (3, 4), (2, 5), (2, 6), (4, 7),
                          (4, 8), (4, 9), (9, 10), (10, 11), (9, 12), (9, 13),
-                         (11, 14), (11, 15), (11, 16)], {}, {}),
+                         (11, 14), (11, 15), (11, 16)], {}, {}, {}),
                         # uncomsumed bonding IDs; note that this is not the same
                         # molecule as previous test case. Here one of the OH branches
                         # and replaces an CH2 group with CH-OH
@@ -103,7 +103,7 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                         'O H C O C H H H H C O C H H H H O H',
                         [(0, 1), (0, 2), (2, 3), (2, 5), (2, 11), (3, 4),
                          (4, 6), (4, 7), (4, 8), (9, 10), (9, 12), (9, 13),
-                         (10, 11), (11, 15), (11, 14), (9, 16), (16, 17)], {}, {}),
+                         (10, 11), (11, 15), (11, 14), (9, 16), (16, 17)], {}, {}, {}),
                         # simple branched sequence
                         ("{[#Hter][#PE]([#PEO][#Hter])[#PE]([#PEO][#Hter])[#Hter]}.{#Hter=[$]H,#PE=[$]CC[$][$],#PEO=[$]COC[$]}",
                         [('Hter', 'H'), ('PE', 'C C H H H'), ('PEO', 'C O C H H H H'), ('Hter', 'H'),
@@ -111,7 +111,7 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                         'H C C H H H C O C H H H H H C C H H H C O C H H H H H H',
                         [(0, 1), (1, 2), (1, 3), (1, 4), (2, 5), (2, 6), (2, 14), (6, 7), (6, 9), (6, 10), (7, 8),
                          (8, 11), (8, 12), (8, 13), (14, 15), (14, 16), (14, 17), (15, 18), (15, 19), (15, 27),
-                         (19, 20), (19, 22), (19, 23), (20, 21), (21, 24), (21, 25), (21, 26)], {}, {}),
+                         (19, 20), (19, 22), (19, 23), (20, 21), (21, 24), (21, 25), (21, 26)], {}, {}, {}),
                         # something with a ring
                         #            012 34567
                         #            890123456
@@ -124,7 +124,7 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                          (6, 14), (7, 8), (7, 15), (8, 16), (17, 18), (17, 25),
                          (17, 26), (18, 19), (18, 27), (18, 33), (19, 20), (19, 24),
                          (20, 21), (20, 28), (21, 22), (21, 29), (22, 23), (22, 30),
-                         (23, 24), (23, 31), (24, 32)], {}, {}),
+                         (23, 24), (23, 31), (24, 32)], {}, {}, {}),
                         # something more complicated branched
                         # here we have multiple bonding descriptors
 #                       # despite being the same residue we have 3 fragments after adding hydrgens
@@ -146,7 +146,7 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                         [('A', 'O H C H H'), ('B', 'C H H C H H H'),],
                         'O H C H H C H H H',
                         [(0, 1), (0, 2), (2, 3), (2, 4), (2, 5),
-                         (5, 6), (5, 7), (5, 8)], {}, {}),
+                         (5, 6), (5, 7), (5, 8)], {}, {}, {}),
                         # smiple squash operator; unconsumed operators
                         ("{[#A][#B]}.{#A=OC[!],#B=[$][!]CC}",
                         #       0 1 2 3 4           1 5 3 4 6 7 8
@@ -157,7 +157,7 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                         [('A', 'O H C H H'), ('B', 'C H H C H H H'),],
                         'O H C H H C H H H',
                         [(0, 1), (0, 2), (2, 3), (2, 4), (2, 5),
-                         (5, 6), (5, 7), (5, 8)], {}, {}),
+                         (5, 6), (5, 7), (5, 8)], {}, {}, {}),
                         # smiple squash operator; plus connect operator
                         ("{[#A][#B][#C]}.{#A=OC[!],#B=[$][!]CC,#C=[$]O}",
                         #       0 1 2 3 4           1 5 3 4 6 7 8
@@ -168,7 +168,7 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                         [('A', 'O H C H'), ('B', 'C H C H H H'), ('C', 'O H')],
                         'O H C H C H H H O H',
                         [(0, 1), (0, 2), (2, 3), (2, 4),
-                         (4, 5), (4, 6), (4, 7), (2, 8), (8, 9)], {}, {}),
+                         (4, 5), (4, 6), (4, 7), (2, 8), (8, 9)], {}, {}, {}),
                         # THF like test case with double edge and squash operator
                         ("{[#A]=[#B]}.{#A=[!]COC[!],#B=[!]CCCC[!]}",
                         [('A', 'O C C H H H H'),
@@ -176,7 +176,7 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                         'O C C H H H H C C H H H H',
                         [(0, 2), (0, 3), (2, 4), (2, 5),
                          (3, 6), (3, 7), (2, 8), (3, 9),
-                         (8, 9), (9, 12), (9, 13), (8, 10), (8, 11)], {}, {}),
+                         (8, 9), (9, 12), (9, 13), (8, 10), (8, 11)], {}, {}, {}),
                         # Toluene like test case with squash operator and aromaticity
                         ("{[#SC3]1[#TC5][#TC5]1}.{#SC3=Cc(c[!])c[!],#TC5=[!]ccc[!]}",
                         [('SC3', 'C C H H H C H C H'),
@@ -184,7 +184,7 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                         'C C H H H C H C H C H C H C H',
                         [(0, 1), (0, 2), (0, 3), (0, 4), (1, 5),
                          (1, 7), (5, 9), (5, 6), (7, 13), (7, 8),
-                         (9, 11), (9, 10), (11, 13), (11, 12), (13, 14)], {}, {}),
+                         (9, 11), (9, 10), (11, 13), (11, 12), (13, 14)], {}, {}, {}),
                          # simple chirality assigment with rings
                          ("{[#GLC]}.{#GLC=C([C@@H]1[C@H]([C@@H]([C@H]([C@H](O1)O)O)O)O)O}",
                          # 0 1 2 3
@@ -194,7 +194,7 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                           (2, 15), (3, 4), (3, 9), (3, 16), (4, 5), (4, 8), (4, 17), (5, 6), (5, 7), (5, 18),
                           (7, 19), (8, 20), (9, 21), (10, 22), (11, 23)],
                          {1: (6, 14, 2, 0), 2: (1, 15, 3, 10), 3: (2, 16, 9, 4),
-                          4: (3, 17, 5, 8), 5: (4, 18, 6, 7)}, {}),
+                          4: (3, 17, 5, 8), 5: (4, 18, 6, 7)}, {}, {}),
                         # simple chirality assigment between fragments
                         ("{[#A][#B][#C]}.{#A=O[>],#C=O[<],#B=[<]C[C@H][>]C(=O)OC}",
                         # 0 1 2 3
@@ -204,7 +204,7 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                         [(0, 1), (0, 2), (2, 3), (2, 4),
                          (2, 5), (5, 6), (5, 7), (7, 8), (7, 9), (9, 10), (10, 11), (10, 12),
                          (10, 13), (5, 14), (14, 15)],
-                        {3: (2, 10, 4, 14)}, {}),
+                        {3: (2, 10, 4, 14)}, {}, {}),
                         # simple chirality assigment between fragments inv
                         ("{[#A][#B][#C]}.{#A=O[>],#C=O[<],#B=[<]C[C@@H][>]C(=O)OC}",
                         # 0 1 2 3
@@ -214,21 +214,21 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                         [(0, 1), (0, 2), (2, 3), (2, 4),
                          (2, 5), (5, 6), (5, 7), (7, 8), (7, 9), (9, 10), (10, 11), (10, 12),
                          (10, 13), (5, 14), (14, 15)],
-                        {3: (2, 10, 14, 4)}, {}),
+                        {3: (2, 10, 14, 4)}, {}, {}),
                         # smiple ez isomerism assigment between fragments inv
                         ("{[#A][#B]}.{#A=CC(/F)=[$],#B=[$]=C(\F)C}",
                         [('A', 'C C F H H H'), ('B', 'C F C H H H')],
                         'C C F H H H F C C H H H',
                         [(0, 1), (1, 2), (0, 3), (0, 4),
                          (0, 5), (1, 7), (7, 6), (7, 8), (8, 9), (8, 10), (8, 11)],
-                        {}, {2: (2, 1, 6, 7, 'trans'), 7: (7, 6, 1, 2, 'trans')}),
+                        {}, {2: (2, 1, 6, 7, 'trans'), 7: (7, 6, 1, 2, 'trans')}, {}),
                         # simple ez isomerism assigment between fragments inv
                         ("{[#A][#B]}.{#A=CC(/F)=[$],#B=[$]=C(/F)C}",
                         [('A', 'C C F H H H'), ('B', 'C F C H H H')],
                         'C C F H H H F C C H H H',
                         [(0, 1), (1, 2), (0, 3), (0, 4),
                          (0, 5), (1, 7), (7, 6), (7, 8), (8, 9), (8, 10), (8, 11)],
-                        {}, {2: (2, 1, 6, 7, 'cis'), 7: (7, 6, 1, 2, 'cis')}),
+                        {}, {2: (2, 1, 6, 7, 'cis'), 7: (7, 6, 1, 2, 'cis')}, {}),
                         # test skip virtual nodes
                         ("{[#SP4]1.2[#SP4].3[#SP1r]1.[#TC4]23}.{#SP4=OC[$]C[$]O,#SP1r=[$]OC[$]CO}",
                         [('SP4', 'O C C O H H H H'), ('SP4', 'O C C O H H H H'),
@@ -238,9 +238,29 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                          (3, 7), (8, 9), (8, 12), (9, 10), (9, 13), (10, 11), (10, 17),
                          (10, 14), (11, 15), (16, 17), (17, 18), (17, 20), (18, 19),
                          (18, 21), (18, 22), (19, 23)],
-                        {},{}),
+                        {},{}, {}),
+                        # test weights
+                        ("{[#SP4]1[#SP4][#SP1r]1}.{#SP4=[OH;0.5]C[$]C[$]O,#SP1r=[$]OC[$]CO}",
+                        [('SP4', 'O C C O H H H H'), ('SP4', 'O C C O H H H H'),
+                         ('SP1r', 'O C C O H H H H')],
+                        'O C C O H H H H O C C O H H H H O C C O H H H H',
+                        [(0, 1), (0, 4), (1, 2), (1, 9), (1, 5), (2, 3), (2, 16), (2, 6),
+                         (3, 7), (8, 9), (8, 12), (9, 10), (9, 13), (10, 11), (10, 17),
+                         (10, 14), (11, 15), (16, 17), (17, 18), (17, 20), (18, 19),
+                         (18, 21), (18, 22), (19, 23)],
+                        {},{}, {0: 0.5, 4: 0.5, 8: 0.5, 12: 0.5}),
+                        # test 2 weights
+                        ("{[#SP4]1[#SP4][#SP1r]1}.{#SP4=[OH;0.5][C;0.1][$]C[$]O,#SP1r=[$]OC[$]CO}",
+                        [('SP4', 'O C C O H H H H'), ('SP4', 'O C C O H H H H'),
+                         ('SP1r', 'O C C O H H H H')],
+                        'O C C O H H H H O C C O H H H H O C C O H H H H',
+                        [(0, 1), (0, 4), (1, 2), (1, 9), (1, 5), (2, 3), (2, 16), (2, 6),
+                         (3, 7), (8, 9), (8, 12), (9, 10), (9, 13), (10, 11), (10, 17),
+                         (10, 14), (11, 15), (16, 17), (17, 18), (17, 20), (18, 19),
+                         (18, 21), (18, 22), (19, 23)],
+                        {},{}, {0: 0.5, 1: 0.1, 5: 0.1, 4: 0.5, 8: 0.5, 9: 0.1, 12: 0.5, 13: 0.1}),
 ))
-def test_all_atom_resolve_molecule(smile, ref_frags, elements, ref_edges, chiral, ez):
+def test_all_atom_resolve_molecule(smile, ref_frags, elements, ref_edges, chiral, ez, weights):
     meta_mol, molecule = MoleculeResolver.from_string(smile).resolve()
 
     # loop and compare fragments first
@@ -278,6 +298,12 @@ def test_all_atom_resolve_molecule(smile, ref_frags, elements, ref_edges, chiral
     if ez:
         ez_assigned = nx.get_node_attributes(molecule, 'ez_isomer')
         assert ez == ez_assigned
+    # check weights
+    if weights:
+        mol_weights = {node: 1 for node in ref_graph}
+        mol_weights.update(weights)
+        weights_assigned = nx.get_node_attributes(molecule, 'weight')
+        assert mol_weights == weights_assigned
 
 @pytest.mark.parametrize('case, cgsmiles_str, ref_string',(
     # case 1: here only the meta-graph is described by the

--- a/cgsmiles/tests/test_molecule_resolve.py
+++ b/cgsmiles/tests/test_molecule_resolve.py
@@ -170,7 +170,7 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                         [(0, 1), (0, 2), (2, 3), (2, 4),
                          (4, 5), (4, 6), (4, 7), (2, 8), (8, 9)], {}, {}),
                         # THF like test case with double edge and squash operator
-                        ("{[#A]1[#B]1}.{#A=[!]COC[!],#B=[!]CCCC[!]}",
+                        ("{[#A]=[#B]}.{#A=[!]COC[!],#B=[!]CCCC[!]}",
                         [('A', 'O C C H H H H'),
                          ('B', 'C C H H H H C C H H H H')],
                         'O C C H H H H C C H H H H',
@@ -185,6 +185,16 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                         [(0, 1), (0, 2), (0, 3), (0, 4), (1, 5),
                          (1, 7), (5, 9), (5, 6), (7, 13), (7, 8),
                          (9, 11), (9, 10), (11, 13), (11, 12), (13, 14)], {}, {}),
+                         # simple chirality assigment with rings
+                         ("{[#GLC]}.{#GLC=C([C@@H]1[C@H]([C@@H]([C@H]([C@H](O1)O)O)O)O)O}",
+                         # 0 1 2 3
+                         [('GLC', 'C C C C C C O O O O O O H H H H H H H H H H H H')],
+                         'C C C C C C O O O O O O H H H H H H H H H H H H',
+                         [(0, 1), (0, 11), (0, 12), (0, 13), (1, 2), (1, 6), (1, 14), (2, 3), (2, 10),
+                          (2, 15), (3, 4), (3, 9), (3, 16), (4, 5), (4, 8), (4, 17), (5, 6), (5, 7), (5, 18),
+                          (7, 19), (8, 20), (9, 21), (10, 22), (11, 23)],
+                         {1: (6, 14, 2, 0), 2: (1, 15, 3, 10), 3: (2, 16, 9, 4),
+                          4: (3, 17, 5, 8), 5: (4, 18, 6, 7)}, {}),
                         # simple chirality assigment between fragments
                         ("{[#A][#B][#C]}.{#A=O[>],#C=O[<],#B=[<]C[C@H][>]C(=O)OC}",
                         # 0 1 2 3
@@ -195,16 +205,6 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                          (2, 5), (5, 6), (5, 7), (7, 8), (7, 9), (9, 10), (10, 11), (10, 12),
                          (10, 13), (5, 14), (14, 15)],
                         {3: (2, 10, 4, 14)}, {}),
-                        # simple chirality assigment with rings
-                        ("{[#GLC]}.{#GLC=C([C@@H]1[C@H]([C@@H]([C@H]([C@H](O1)O)O)O)O)O}",
-                        # 0 1 2 3
-                        [('GLC', 'C C C C C C O O O O O O H H H H H H H H H H H H')],
-                        'C C C C C C O O O O O O H H H H H H H H H H H H',
-                        [(0, 1), (0, 11), (0, 12), (0, 13), (1, 2), (1, 6), (1, 14), (2, 3), (2, 10),
-                         (2, 15), (3, 4), (3, 9), (3, 16), (4, 5), (4, 8), (4, 17), (5, 6), (5, 7), (5, 18),
-                         (7, 19), (8, 20), (9, 21), (10, 22), (11, 23)],
-                        {1: (6, 14, 2, 0), 2: (1, 15, 3, 10), 3: (2, 16, 9, 4),
-                         4: (3, 17, 5, 8), 5: (4, 18, 6, 7)}, {}),
                         # simple chirality assigment between fragments inv
                         ("{[#A][#B][#C]}.{#A=O[>],#C=O[<],#B=[<]C[C@@H][>]C(=O)OC}",
                         # 0 1 2 3
@@ -229,6 +229,16 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                         [(0, 1), (1, 2), (0, 3), (0, 4),
                          (0, 5), (1, 7), (7, 6), (7, 8), (8, 9), (8, 10), (8, 11)],
                         {}, {2: (2, 1, 6, 7, 'cis'), 7: (7, 6, 1, 2, 'cis')}),
+                        # test skip virtual nodes
+                        ("{[#SP4]1.2[#SP4].3[#SP1r]1.[#TC4]23}.{#SP4=OC[$]C[$]O,#SP1r=[$]OC[$]CO}",
+                        [('SP4', 'O C C O H H H H'), ('SP4', 'O C C O H H H H'),
+                         ('SP1r', 'O C C O H H H H')],
+                        'O C C O H H H H O C C O H H H H O C C O H H H H',
+                        [(0, 1), (0, 4), (1, 2), (1, 9), (1, 5), (2, 3), (2, 16), (2, 6),
+                         (3, 7), (8, 9), (8, 12), (9, 10), (9, 13), (10, 11), (10, 17),
+                         (10, 14), (11, 15), (16, 17), (17, 18), (17, 20), (18, 19),
+                         (18, 21), (18, 22), (19, 23)],
+                        {},{}),
 ))
 def test_all_atom_resolve_molecule(smile, ref_frags, elements, ref_edges, chiral, ez):
     meta_mol, molecule = MoleculeResolver.from_string(smile).resolve()
@@ -240,6 +250,7 @@ def test_all_atom_resolve_molecule(smile, ref_frags, elements, ref_edges, chiral
         block_graph = meta_mol.nodes[node]['graph']
         target_elements = nx.get_node_attributes(block_graph, 'element')
         sorted_elements =  [target_elements[key] for key in sorted(target_elements)]
+        print(target_elements)
         print("-->", sorted_elements)
         print("-->", ref[1].split())
         assert sorted_elements == ref[1].split()

--- a/cgsmiles/tests/test_sampler.py
+++ b/cgsmiles/tests/test_sampler.py
@@ -104,6 +104,7 @@ def test_add_fragment(graph_str,
     ref_graph = read_cgsmiles(ref_mol)
     nx.set_node_attributes(ref_graph, bonding, 'bonding')
     nx.set_node_attributes(ref_graph, fragid, 'fragid')
+    nx.set_node_attributes(ref_graph, 1, 'weight')
     atomnames = nx.get_node_attributes(ref_graph, 'fragname')
     nx.set_node_attributes(ref_graph, atomnames, 'atomname')
     nx.set_node_attributes(ref_graph, resnames, 'fragname')

--- a/cgsmiles/tests/test_write_cgsmiles.py
+++ b/cgsmiles/tests/test_write_cgsmiles.py
@@ -38,9 +38,9 @@ def test_write_fragments(input_string):
                         # branched nested
                         "{[#PE][#PMA]([#PEO][#PEO]([#OMA][#OMA]1[#OMA][#OMA]1))[#PE]}",
                         # special cycle
-                        "{[#PE]1[#PMA]1}",
+                        "{[#PE]=[#PMA]}",
                         # special triple cycle
-                        "{[#A]12[#B]12}",
+                        "{[#A]#[#B]}",
 ))
 def test_write_mol_graphs(input_string):
     mol_graph = read_cgsmiles(input_string)

--- a/cgsmiles/write_cgsmiles.py
+++ b/cgsmiles/write_cgsmiles.py
@@ -86,16 +86,6 @@ def write_graph(molecule, smiles_format=False, default_element='*'):
             edges.add(frozenset((n_idx, n_jdx)))
     total_edges = set(map(frozenset, molecule.edges))
     ring_edges = list(total_edges - edges)
-    # in cgsmiles graphs only bonds of order 1 and 2
-    # exists; order 2 means we have a ring at the
-    # higher resolution. These orders are therefore
-    # represented as rings and that requires to
-    # add them to the ring list
-    if not smiles_format:
-        for edge in molecule.edges:
-            if molecule.edges[edge]['order'] != 1:
-                for n in range(1, molecule.edges[edge]['order']):
-                    ring_edges.append(frozenset(edge))
 
     atom_to_ring_idx = defaultdict(list)
     ring_idx_to_bond = {}
@@ -123,7 +113,7 @@ def write_graph(molecule, smiles_format=False, default_element='*'):
             previous = predecessors[current]
             assert len(previous) == 1
             previous = previous[0]
-            if smiles_format and _write_edge_symbol(molecule, previous, current):
+            if _write_edge_symbol(molecule, previous, current):
                 order = molecule.edges[previous, current].get('order', 1)
                 smiles += order_to_symbol[order]
 


### PR DESCRIPTION
Martini CG mappings are a curious thing; More complex molecules frequently have atoms that are ignored in the mapping (i.e. zero weight) or reweighted. This PR implements a syntax for this. Optionally, nodes can be given weight using`[node;weight]`, where weight may be a float. Hydrogens need not be given as we figure them out later, but canonically speaking, it would be better. Annotation of the weight may occur before or after the chirality operator. A default weight of 1 is given to all nodes. Hydrogen atoms unless explicit get the same weight as the node they are attached to. 

For example, hexadecane but we map only the central two carbons: `{[#C1]|4}.{#C1=[C;0]CC[C;0]}`