### PR TITLE
MAINT: improve error with SMILES

### DIFF
--- a/cgsmiles/resolve.py
+++ b/cgsmiles/resolve.py
@@ -430,6 +430,9 @@ class MoleculeResolver:
         """
         # here we figure out how many resolutions we are dealing with
         elements = re.findall(r"\{[^\}]+\}", cgsmiles_str)
+        if len(elements) == 0:
+            raise SyntaxError("No polymeric fragments detected; likely "
+                              "not a valid CGSmiles/BigSMILES string.")
         # the first one describes our lowest resolution
         molecule = read_cgsmiles(elements[0])
         # the rest are fragment lists

--- a/cgsmiles/tests/test_molecule_resolve.py
+++ b/cgsmiles/tests/test_molecule_resolve.py
@@ -310,6 +310,8 @@ def test_resolve_cases(case, cgsmiles_str, ref_string):
 (("{[#A][#B]}.{#A=CC[$]}", "Found node #B but no corresponding fragment."),
  ("{[#A][#B]1}.{#A=CC[$],#B=OC[$]}", "You have a dangling ring index."),
  ("{[#A]1[#B]1}{#A=CC[$],#B=OC[$]}", "You define two edges between the same node. Use bond order symbols instead."),
+ # see: https://github.com/marrink-lab/polyply_1.0/issues/390#issuecomment-2455472121
+ ("CC(c1ccccc1)CC(c1ccccc1)CCCCCCCCCC(CC)CC(CC)CC(c1ccccc1)CC(c1ccccc1)", "No polymeric fragments detected; likely not a valid CGSmiles/BigSMILES string."),
 )))
 def test_syntax_errors(cgsmiles_str, error_message):
     with pytest.raises(SyntaxError) as e_message:


### PR DESCRIPTION
* The error message when processing conventional SMILES strings can be confusing, as observed at:
https://github.com/marrink-lab/polyply_1.0/issues/390#issuecomment-2455472121

* For cases like that where there are no polymeric fragments (i.e., no use of braces), this patch improves the error message (and adds a test for it) to nudge the user to BigSMILES or CGSmiles formats.