### PR TITLE
Maint

### DIFF
--- a/cgsmiles/graph_utils.py
+++ b/cgsmiles/graph_utils.py
@@ -175,7 +175,9 @@ def set_atom_names_atomistic(molecule, meta_graph=None):
             assert len(fragids) == 1
             fraglist[fragids[0]].append(node)
 
-    for fragnodes in fraglist.values():
+    for meta_node, fragnodes in fraglist.items():
         for idx, node in enumerate(fragnodes):
             atomname = molecule.nodes[node]['element'] + str(idx)
             molecule.nodes[node]['atomname'] = atomname
+            if meta_graph:
+                meta_graph.nodes[meta_node]['graph'].nodes[node]['atomname'] = atomname

--- a/cgsmiles/pysmiles_utils.py
+++ b/cgsmiles/pysmiles_utils.py
@@ -67,12 +67,12 @@ def rebuild_h_atoms(mol_graph, keep_bonding=False):
         pysmiles.smiles_helper.correct_aromatic_rings(mol_graph, strict=True)
     except SyntaxError as pysmiles_err:
         print(pysmiles_err)
-        msg = (r"Likely you are writing an aromatic molecule that does not "
-               r"show delocalization-induced molecular equivalency and thus "
-               r"is not considered aromatic. For example, 4-methyl imidazole "
-               r"is often written as [nH]1cc(nc1)C, but should be written as "
-               r"[NH]1C=C(N=C1)C. A corresponding CGSmiles string would be "
-               r"{[#A]1[#B][#C]1}.{#A=[>][<]N,#B=[$]N=C[>],#C=[$]C(C)=C[<]}")
+        msg = ("Likely you are writing an aromatic molecule that does not "
+               "show delocalization-induced molecular equivalency and thus "
+               "is not considered aromatic. For example, 4-methyl imidazole "
+               "is often written as [nH]1cc(nc1)C, but should be written as "
+               "[NH]1C=C(N=C1)C. A corresponding CGSmiles string would be "
+               "{[#A]1[#B][#C]1}.{#A=[>][<]N,#B=[$]N=C[>],#C=[$]C(C)=C[<]}")
         raise SyntaxError(msg)
     nx.set_node_attributes(mol_graph, 0, 'hcount')
 
@@ -84,8 +84,6 @@ def rebuild_h_atoms(mol_graph, keep_bonding=False):
     if keep_bonding:
         bonding_nodes = nx.get_node_attributes(mol_graph, 'bonding')
         for node, bond_ops in bonding_nodes.items():
-            print(bond_ops)
-            print(sum([int(bond[-1]) for bond in bond_ops]))
             mol_graph.nodes[node]['hcount'] -= sum([int(bond[-1]) for bond in bond_ops])
 
     # now we add the hydrogen atoms

--- a/cgsmiles/pysmiles_utils.py
+++ b/cgsmiles/pysmiles_utils.py
@@ -67,12 +67,12 @@ def rebuild_h_atoms(mol_graph, keep_bonding=False):
         pysmiles.smiles_helper.correct_aromatic_rings(mol_graph, strict=True)
     except SyntaxError as pysmiles_err:
         print(pysmiles_err)
-        msg = ("Likely you are writing an aromatic molecule that does not "
-               "show delocalization-induced molecular equivalency and thus "
-               "is not considered aromatic. For example, 4-methyl imidazole "
-               "is often written as [nH]1cc(nc1)C, but should be written as "
-               "[NH]1C=C(N=C1)C. A corresponding CGSmiles string would be "
-               "{[#A]1[#B][#C]1}.{#A=[>][<]N,#B=[$]N=C[>],#C=[$]C(C)=C[<]}")
+        msg = (r"Likely you are writing an aromatic molecule that does not "
+               r"show delocalization-induced molecular equivalency and thus "
+               r"is not considered aromatic. For example, 4-methyl imidazole "
+               r"is often written as [nH]1cc(nc1)C, but should be written as "
+               r"[NH]1C=C(N=C1)C. A corresponding CGSmiles string would be "
+               r"{[#A]1[#B][#C]1}.{#A=[>][<]N,#B=[$]N=C[>],#C=[$]C(C)=C[<]}")
         raise SyntaxError(msg)
     nx.set_node_attributes(mol_graph, 0, 'hcount')
 
@@ -84,7 +84,9 @@ def rebuild_h_atoms(mol_graph, keep_bonding=False):
     if keep_bonding:
         bonding_nodes = nx.get_node_attributes(mol_graph, 'bonding')
         for node, bond_ops in bonding_nodes.items():
-            mol_graph.nodes[node]['hcount'] -= len(bond_ops)
+            print(bond_ops)
+            print(sum([int(bond[-1]) for bond in bond_ops]))
+            mol_graph.nodes[node]['hcount'] -= sum([int(bond[-1]) for bond in bond_ops])
 
     # now we add the hydrogen atoms
     pysmiles.smiles_helper.add_explicit_hydrogens(mol_graph)

--- a/cgsmiles/read_fragments.py
+++ b/cgsmiles/read_fragments.py
@@ -158,10 +158,10 @@ def strip_bonding_descriptors(fragment_string):
                     else:
                         atom += peek
                     peek = next(smile_iter)
-
                 smile = smile + atom + "]"
                 prev_node = node_count
                 node_count += 1
+                current_order = None
         elif token == '(':
             anchor.append(prev_node)
             smile += token

--- a/cgsmiles/read_fragments.py
+++ b/cgsmiles/read_fragments.py
@@ -126,6 +126,7 @@ def strip_bonding_descriptors(fragment_string):
     node_count = 0
     prev_node = 0
     current_order = None
+    anchor = []
     for token in smile_iter:
         if token == '[':
             peek = next(smile_iter)
@@ -162,10 +163,10 @@ def strip_bonding_descriptors(fragment_string):
                 prev_node = node_count
                 node_count += 1
         elif token == '(':
-            anchor = prev_node
+            anchor.append(prev_node)
             smile += token
         elif token == ')':
-            prev_node = anchor
+            prev_node = anchor.pop()
             smile += token
         elif token in bond_to_order:
             current_order = bond_to_order[token]

--- a/cgsmiles/resolve.py
+++ b/cgsmiles/resolve.py
@@ -382,18 +382,16 @@ class MoleculeResolver:
             mark_chiral_atoms(self.molecule)
             # assign rs isomerism
             annotate_ez_isomers(self.molecule)
-            # in all-atom MD there are common naming conventions
-            # that might be expected and hence we set them here
-            set_atom_names_atomistic(self.molecule, self.meta_graph)
 
         # and redo the meta molecule
         self.meta_graph = annotate_fragments(self.meta_graph,
                                              self.molecule)
 
-        # in all-atom MD there are common naming conventions
-        # that might be expected and hence we set them here
         if all_atom:
-            set_atom_names_atomistic(self.molecule, self.meta_graph)
+            # in all-atom MD there are common naming conventions
+            # that might be expected and hence we set them here
+            set_atom_names_atomistic(self.molecule,
+                                     self.meta_graph)
 
         # increment the resolution counter
         self.resolution_counter += 1

--- a/cgsmiles/tests/test_cgsmile_parsing.py
+++ b/cgsmiles/tests/test_cgsmile_parsing.py
@@ -269,6 +269,18 @@ def test_read_cgsmiles(smile, nodes, charges, edges, orders):
                         {0: ["$1"], 2: ["$1"]},
                         None,
                         None),
+                        # smiple symmetric bonding after branch
+                        ("[$]CC(CC)[$]",
+                         "CC(CC)",
+                        {0: ["$1"], 1: ["$1"]},
+                        None,
+                        None),
+                        # smiple symmetric bonding after ring
+                        ("[$]CC1[$]CCC1",
+                         "CC1CCC1",
+                        {0: ["$1"], 1: ["$1"]},
+                        None,
+                        None),
                         # smiple symmetric bonding with more than one name
                         ("[$1A]COC[$1A]",
                          "COC",

--- a/cgsmiles/tests/test_cgsmile_parsing.py
+++ b/cgsmiles/tests/test_cgsmile_parsing.py
@@ -293,6 +293,12 @@ def test_read_cgsmiles(smile, nodes, charges, edges, orders):
                         {1: ["$a2", "$b2"]},
                         None,
                         None),
+                        # multiple non-one bonding l
+                        ("CC[$a]=[$b]CC",
+                         "CCCC",
+                        {1: ["$a1", "$b2"]},
+                        None,
+                        None),
                         # smiple symmetric bonding with more than one name
                         ("[$1A]COC[$1A]",
                          "COC",

--- a/cgsmiles/tests/test_cgsmile_parsing.py
+++ b/cgsmiles/tests/test_cgsmile_parsing.py
@@ -281,6 +281,12 @@ def test_read_cgsmiles(smile, nodes, charges, edges, orders):
                         {0: ["$1"], 1: ["$1"]},
                         None,
                         None),
+                        # clear order symbol
+                        ("[CH][$a]=[CH][$c]",
+                         "[CH]=[CH]",
+                        {0: ["$a1"], 1: ["$c1"]},
+                        None,
+                        None),
                         # smiple symmetric bonding with more than one name
                         ("[$1A]COC[$1A]",
                          "COC",

--- a/cgsmiles/tests/test_cgsmile_parsing.py
+++ b/cgsmiles/tests/test_cgsmile_parsing.py
@@ -287,6 +287,12 @@ def test_read_cgsmiles(smile, nodes, charges, edges, orders):
                         {0: ["$a1"], 1: ["$c1"]},
                         None,
                         None),
+                        # multiple non-one bonding l
+                        ("CC=[$a]=[$b]CC",
+                         "CCCC",
+                        {1: ["$a2", "$b2"]},
+                        None,
+                        None),
                         # smiple symmetric bonding with more than one name
                         ("[$1A]COC[$1A]",
                          "COC",

--- a/cgsmiles/tests/test_utils.py
+++ b/cgsmiles/tests/test_utils.py
@@ -1,0 +1,32 @@
+import re
+import pytest
+import cgsmiles
+
+err_msg_rebuild_h = ("Likely you are writing an aromatic molecule that does not "
+                     "show delocalization-induced molecular equivalency and thus "
+                     "is not considered aromatic. For example, 4-methyl imidazole "
+                     "is often written as [nH]1cc(nc1)C, but should be written as "
+                     "[NH]1C=C(N=C1)C. A corresponding CGSmiles string would be "
+                     "{[#A]1[#B][#C]1}.{#A=[>][<]N,#B=[$]N=C[>],#C=[$]C(C)=C[<]}")
+
+@pytest.mark.parametrize('frag_str, hatoms_ref, error_type, err_msg', (
+                        ('{#A=[$]CCC[$]}', 6, None, None),
+                        ('{#A=CCC}', 8, None, None),
+                        ('{#A=C[!]CC}', 7, None, None),
+                        ('{#A=[$]=CCC=[$]}', 4, None, None),
+                        ('{#A=[$]cccc}',5, None, None),
+                        ('{#A=[$]ccc}', 0, SyntaxError, err_msg_rebuild_h),
+))
+def test_rebuild_hatoms(frag_str, hatoms_ref, error_type, err_msg):
+    frag_dict = cgsmiles.read_fragments(frag_str)
+    frag_graph = frag_dict['A']
+    if error_type:
+        with pytest.raises(error_type, match=re.escape(err_msg)):
+            cgsmiles.pysmiles_utils.rebuild_h_atoms(frag_graph, keep_bonding=True)
+    else:
+        cgsmiles.pysmiles_utils.rebuild_h_atoms(frag_graph, keep_bonding=True)
+        hatoms = 0
+        for node, ele in frag_graph.nodes(data='element'):
+            if ele == 'H':
+                hatoms += 1
+        assert hatoms == hatoms_ref


### PR DESCRIPTION
Collection of maintenance things. This PR fixes:

- #30 #16 bond orders are now cleared after an atom has been parsed; this also fixes issue #16 
- #15 is fixed and now also takes into account bond orders; in addition, new tests cover previously untested error
- [#394](https://github.com/marrink-lab/polyply_1.0/issues/394) from polyply is fixed; the atom names are now updated both in the meta-graph and molecule if a meta graph is provided. This fix also removes the need for calling the naming function twice
- 