### PR TITLE
Chiral

### DIFF
--- a/cgsmiles/pysmiles_utils.py
+++ b/cgsmiles/pysmiles_utils.py
@@ -2,7 +2,6 @@ import logging
 import networkx as nx
 import pysmiles
 from pysmiles.smiles_helper import (_annotate_ez_isomers,
-                                    _mark_chiral_atoms,
                                     remove_explicit_hydrogens,
                                     add_explicit_hydrogens)
 
@@ -75,7 +74,6 @@ def rebuild_h_atoms(mol_graph, keep_bonding=False):
                "{[#A]1[#B][#C]1}.{#A=[>][<]N,#B=[$]N=C[>],#C=[$]C(C)=C[<]}")
         raise SyntaxError(msg)
     nx.set_node_attributes(mol_graph, 0, 'hcount')
-
     pysmiles.smiles_helper.fill_valence(mol_graph, respect_hcount=False)
     pysmiles.smiles_helper.add_explicit_hydrogens(mol_graph)
 
@@ -109,61 +107,3 @@ def annotate_ez_isomers(molecule):
     for node in ez_isomer_atoms:
         del  molecule.nodes[node]['ez_isomer_atoms']
         del  molecule.nodes[node]['ez_isomer_class']
-
-def mark_chiral_atoms(molecule):
-    """
-    For all nodes tagged as chiral, figure out the three
-    substituents and annotate the node with a tuple that
-    has the order in which to rotate. This essentially
-    corresponds to the definition of an improper dihedral
-    angle centered on the chiral atom.
-
-    Pysmiles treats explicit hydrogen atoms differently
-    from implicit ones. In cgsmiles at the time when this
-    function is called all hydrogen atoms have been added
-    explicitly. However, we need to correct the chirality
-    assigment for this.
-
-    Note that this means it is not possible to have explicit
-    hydrogen atoms attached to chiral centers within cgsmiles
-    to begin with. However, this is a rather edge case.
-    """
-    chiral_nodes = nx.get_node_attributes(molecule, 'rs_isomer')
-    for node, (direction, rings) in chiral_nodes.items():
-        # first the ring atoms in order
-        # that they were connected then the
-        # other neighboring atoms in order
-        bonded_neighbours = sorted(molecule[node])
-        neighbours = list(rings)
-        hstash = []
-        for neighbour in bonded_neighbours:
-            if neighbour not in neighbours:
-                # all hydrogen atoms are explicit in cgsmiles
-                # BUT in the input of chirality they are usual
-                # implicit. At this point we need to treat all
-                # hydrogen atoms as if they were implicit.
-                if molecule.nodes[neighbour]['element'] != 'H':
-                    neighbours.append(neighbour)
-                else:
-                    hstash.append(neighbour)
-        if hstash and len(hstash) == 1:
-            neighbours.insert(1, hstash[0])
-        elif len(hstash) > 1:
-            msg = (f"Chiral node {node} as more than 1 hydrogen neighbor."
-                    "Therefore it is not chiral.")
-            raise ValueError(msg)
-
-        if len(neighbours) != 4:
-            # FIXME Tetrahedral Allene-like Systems such as `NC(Br)=[C@]=C(O)C`
-            msg = (f"Chiral node {node} has {len(neighbours)} neighbors, which "
-                    "is different than the four expected for tetrahedral "
-                    "chirality.")
-            raise ValueError(msg)
-        # the default is anti-clockwise sorting indicated by '@'
-        # in this case the nodes are sorted with increasing
-        # node index; however @@ means clockwise and the
-        # order of nodes is reversed (i.e. with decreasing index)
-        if direction == '@@':
-            neighbours = [neighbours[0],  neighbours[1], neighbours[3], neighbours[2]]
-
-        molecule.nodes[node]['rs_isomer'] = tuple(neighbours)

--- a/cgsmiles/resolve.py
+++ b/cgsmiles/resolve.py
@@ -9,8 +9,7 @@ from .graph_utils import (merge_graphs,
                           annotate_fragments,
                           set_atom_names_atomistic)
 from .pysmiles_utils import (rebuild_h_atoms,
-                             annotate_ez_isomers,
-                             mark_chiral_atoms)
+                             annotate_ez_isomers)
 
 def compatible(left, right, legacy=False):
     """
@@ -363,7 +362,6 @@ class MoleculeResolver:
 
         # add disconnected fragments to graph
         self.resolve_disconnected_molecule(fragment_dict)
-
         # connect valid bonding descriptors
         self.edges_from_bonding_descrpt(all_atom=all_atom)
 
@@ -378,8 +376,6 @@ class MoleculeResolver:
         self.molecule = sort_nodes_by_attr(self.molecule, sort_attr=("fragid"))
 
         if all_atom:
-            # assign chiral atoms
-            mark_chiral_atoms(self.molecule)
             # assign rs isomerism
             annotate_ez_isomers(self.molecule)
             # in all-atom MD there are common naming conventions

--- a/cgsmiles/tests/test_cgsmile_parsing.py
+++ b/cgsmiles/tests/test_cgsmile_parsing.py
@@ -318,16 +318,16 @@ def test_read_cgsmiles(smile, nodes, charges, edges, orders):
                         None,
                         None),
                         # simple chirality in residue
-                        ("[>]C[C@](F)(B)N[<]",
+                        ("[>]C[C@R](F)(B)N[<]",
                         "C[C](F)(B)N",
                         {0: [">1"], 4: ["<1"]},
-                        {1: ('@', [])},
+                        {1: '@R'},
                         None),
                         # simple chirality inverse in residue
-                        ("[>]C[C@@](F)(B)N[<]",
+                        ("[>]C[C@S](F)(B)N[<]",
                         "C[C](F)(B)N",
                         {0: [">1"], 4: ["<1"]},
-                        {1: ('@@', [])},
+                        {1: '@S'},
                         None),
                         # \ fragment split
                         ("[>]CC(\F)=[<]",

--- a/cgsmiles/tests/test_molecule_resolve.py
+++ b/cgsmiles/tests/test_molecule_resolve.py
@@ -186,17 +186,17 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                          (1, 7), (5, 9), (5, 6), (7, 13), (7, 8),
                          (9, 11), (9, 10), (11, 13), (11, 12), (13, 14)], {}, {}),
                          # simple chirality assigment with rings
-                         ("{[#GLC]}.{#GLC=C([C@@H]1[C@H]([C@@H]([C@H]([C@H](O1)O)O)O)O)O}",
+                         # (3R,4S,5S,6R)-6-(hydroxymethyl)oxane-2,3,4,5-tetrol (cyclic form)
+                         ("{[#GLC]}.{#GLC=[C@R]([C@S]1[C@S]([C@R](C(C(O1)O)O)O)O)O}",
                          # 0 1 2 3
                          [('GLC', 'C C C C C C O O O O O O H H H H H H H H H H H H')],
                          'C C C C C C O O O O O O H H H H H H H H H H H H',
                          [(0, 1), (0, 11), (0, 12), (0, 13), (1, 2), (1, 6), (1, 14), (2, 3), (2, 10),
                           (2, 15), (3, 4), (3, 9), (3, 16), (4, 5), (4, 8), (4, 17), (5, 6), (5, 7), (5, 18),
                           (7, 19), (8, 20), (9, 21), (10, 22), (11, 23)],
-                         {1: (6, 14, 2, 0), 2: (1, 15, 3, 10), 3: (2, 16, 9, 4),
-                          4: (3, 17, 5, 8), 5: (4, 18, 6, 7)}, {}),
+                         {0: '@R', 1: '@S', 2: '@S', 3: '@R'}, {}),
                         # simple chirality assigment between fragments
-                        ("{[#A][#B][#C]}.{#A=O[>],#C=O[<],#B=[<]C[C@H][>]C(=O)OC}",
+                        ("{[#A][#B][#C]}.{#A=O[>],#C=O[<],#B=[<]C[C@SH][>]C(=O)OC}",
                         # 0 1 2 3
                         [('A', 'O H'), ('B', 'C C C O O C H H H H H H'),
                          ('C', 'O H')],
@@ -204,9 +204,9 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                         [(0, 1), (0, 2), (2, 3), (2, 4),
                          (2, 5), (5, 6), (5, 7), (7, 8), (7, 9), (9, 10), (10, 11), (10, 12),
                          (10, 13), (5, 14), (14, 15)],
-                        {3: (2, 10, 4, 14)}, {}),
+                        {3: '@S'}, {}),
                         # simple chirality assigment between fragments inv
-                        ("{[#A][#B][#C]}.{#A=O[>],#C=O[<],#B=[<]C[C@@H][>]C(=O)OC}",
+                        ("{[#A][#B][#C]}.{#A=O[>],#C=O[<],#B=[<]C[C@RH][>]C(=O)OC}",
                         # 0 1 2 3
                         [('A', 'O H'), ('B', 'C C C O O C H H H H H H'),
                          ('C', 'O H')],
@@ -214,7 +214,7 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                         [(0, 1), (0, 2), (2, 3), (2, 4),
                          (2, 5), (5, 6), (5, 7), (7, 8), (7, 9), (9, 10), (10, 11), (10, 12),
                          (10, 13), (5, 14), (14, 15)],
-                        {3: (2, 10, 14, 4)}, {}),
+                        {3: '@R'}, {}),
                         # smiple ez isomerism assigment between fragments inv
                         ("{[#A][#B]}.{#A=CC(/F)=[$],#B=[$]=C(\F)C}",
                         [('A', 'C C F H H H'), ('B', 'C F C H H H')],
@@ -278,7 +278,7 @@ def test_all_atom_resolve_molecule(smile, ref_frags, elements, ref_edges, chiral
 
     # check chirality
     if chiral:
-        chiral_assigned = nx.get_node_attributes(molecule, 'rs_isomer')
+        chiral_assigned = nx.get_node_attributes(molecule, 'chiral')
         assert chiral == chiral_assigned
     # check ez isomerism
     if ez:


### PR DESCRIPTION
Chirality in SMILES sucks. That is an unequivocal truth. 

The main reason is that it relates the order of the nodes in the string to the 3D configuration. For CGSmiles, this is a problem because it is not obvious at all in which order fragments or bonding descriptors in a complex molecule are added. As a user, one can forget about figuring out what the right order should be to get the correct chirality. That is a problem for many simple molecules (e.g. lipids) that only have one chiral center which is well-defined by R/S.

For molecules like sugars, it gets even more messed up. Here, the ordering of ring bonds plays a role for SMILES, but in CGSmiles we cannot guarantee this order to be the same as in the SMILES string. So, simply copying and splitting the SMILES string from another source would almost definitely give the incorrect answer. 

Thus, CGSmiles will simply support annotation with @R, @S, and @RS. A chiral node will be for example `[C@R]`. That means the user needs to decide what a chiral center should be. Any interpretation of the order of the neighbors or what that means is left to the user. 

Is it possible to mess up the notation and generate impossible molecules? For sure, but in my opinion, it is by far outweighed by simple molecules that now have the correct chirality annotation. 

 