### PR TITLE
Chiral note

### DIFF
--- a/cgsmiles/pysmiles_utils.py
+++ b/cgsmiles/pysmiles_utils.py
@@ -2,7 +2,6 @@ import logging
 import networkx as nx
 import pysmiles
 from pysmiles.smiles_helper import (_annotate_ez_isomers,
-                                    _mark_chiral_atoms,
                                     remove_explicit_hydrogens,
                                     add_explicit_hydrogens)
 
@@ -129,68 +128,9 @@ def annotate_ez_isomers(molecule):
         del  molecule.nodes[node]['ez_isomer_atoms']
         del  molecule.nodes[node]['ez_isomer_class']
 
-def mark_chiral_atoms(molecule):
-    """
-    For all nodes tagged as chiral, figure out the three
-    substituents and annotate the node with a tuple that
-    has the order in which to rotate. This essentially
-    corresponds to the definition of an improper dihedral
-    angle centered on the chiral atom.
-
-    Pysmiles treats explicit hydrogen atoms differently
-    from implicit ones. In cgsmiles at the time when this
-    function is called all hydrogen atoms have been added
-    explicitly. However, we need to correct the chirality
-    assigment for this.
-
-    Note that this means it is not possible to have explicit
-    hydrogen atoms attached to chiral centers within cgsmiles
-    to begin with. However, this is a rather edge case.
-    """
-    chiral_nodes = nx.get_node_attributes(molecule, 'rs_isomer')
-    for node, (direction, rings) in chiral_nodes.items():
-        # first the ring atoms in order
-        # that they were connected then the
-        # other neighboring atoms in order
-        bonded_neighbours = sorted(molecule[node])
-        neighbours = list(rings)
-        hstash = []
-        for neighbour in bonded_neighbours:
-            if neighbour not in neighbours:
-                # all hydrogen atoms are explicit in cgsmiles
-                # BUT in the input of chirality they are usual
-                # implicit. At this point we need to treat all
-                # hydrogen atoms as if they were implicit.
-                if molecule.nodes[neighbour]['element'] != 'H':
-                    neighbours.append(neighbour)
-                else:
-                    hstash.append(neighbour)
-        if hstash and len(hstash) == 1:
-            neighbours.insert(1, hstash[0])
-        elif len(hstash) > 1:
-            msg = (f"Chiral node {node} as more than 1 hydrogen neighbor."
-                    "Therefore it is not chiral.")
-            raise ValueError(msg)
-
-        if len(neighbours) != 4:
-            # FIXME Tetrahedral Allene-like Systems such as `NC(Br)=[C@]=C(O)C`
-            msg = (f"Chiral node {node} has {len(neighbours)} neighbors, which "
-                    "is different than the four expected for tetrahedral "
-                    "chirality.")
-            raise ValueError(msg)
-        # the default is anti-clockwise sorting indicated by '@'
-        # in this case the nodes are sorted with increasing
-        # node index; however @@ means clockwise and the
-        # order of nodes is reversed (i.e. with decreasing index)
-        if direction == '@@':
-            neighbours = [neighbours[0],  neighbours[1], neighbours[3], neighbours[2]]
-
-        molecule.nodes[node]['rs_isomer'] = tuple(neighbours)
-
 def read_fragment_smiles(smiles_str,
                          fragname,
                          bonding_descrpt={},
-                         rs_isomers={},
                          ez_isomers={},
                          attributes={}):
     """
@@ -210,7 +150,6 @@ def read_fragment_smiles(smiles_str,
         string in OpenSMILES format
     fragname: str
         the name of the fragment
-    rs_isomers: dict
     ez_isomers: dict
     attributes: dict
 
@@ -269,9 +208,6 @@ def read_fragment_smiles(smiles_str,
     nx.set_node_attributes(mol_graph,
                            dict(zip(hatoms_to_keep, len(hatoms_to_keep)*'H')),
                            'element')
-
-    # annotate rs isomers
-    nx.set_node_attributes(mol_graph, rs_isomers, 'rs_isomer')
 
     # we need to split countable node keys and the associated value
     ez_isomer_atoms = {idx: val[:-1] for idx, val in ez_isomers.items()}

--- a/cgsmiles/resolve.py
+++ b/cgsmiles/resolve.py
@@ -9,8 +9,7 @@ from .graph_utils import (merge_graphs,
                           annotate_fragments,
                           set_atom_names_atomistic)
 from .pysmiles_utils import (rebuild_h_atoms,
-                             annotate_ez_isomers,
-                             mark_chiral_atoms)
+                             annotate_ez_isomers)
 
 def compatible(left, right, legacy=False):
     """
@@ -378,9 +377,6 @@ class MoleculeResolver:
         self.molecule = sort_nodes_by_attr(self.molecule, sort_attr=("fragid"))
 
         if all_atom:
-            # assign chiral atoms
-            mark_chiral_atoms(self.molecule)
-            # assign rs isomerism
             annotate_ez_isomers(self.molecule)
 
         # and redo the meta molecule

--- a/cgsmiles/tests/test_cgsmile_parsing.py
+++ b/cgsmiles/tests/test_cgsmile_parsing.py
@@ -270,12 +270,11 @@ def test_read_cgsmiles(smile, nodes, charges, edges, orders):
         set_charges = nx.get_node_attributes(meta_mol, 'charge')
         assert set_charges == charges
 
-@pytest.mark.parametrize('big_smile, smile, bonding, rs, ez, attrs',(
+@pytest.mark.parametrize('big_smile, smile, bonding,  ez, attrs',(
                         # smiple symmetric bonding
                         ("[$]COC[$]",
                          "COC",
                         {0: ["$1"], 2: ["$1"]},
-                        None,
                         None,
                         None),
                         # smiple symmetric bonding with weight
@@ -283,13 +282,11 @@ def test_read_cgsmiles(smile, nodes, charges, edges, orders):
                          "C[O]C",
                         {0: ["$1"], 2: ["$1"]},
                         None,
-                        None,
                         {'weight': {1: 0.5}}),
                         # smiple kwarg not part of the defaults
                         ("[$]C[O;q=4;p=s][C;q=3;p=l][$]",
                          "C[O][C]",
                         {0: ["$1"], 2: ["$1"]},
-                        None,
                         None,
                         {'q': {1: '4', 2: '3'}, 'p': {1: 's', 2: 'l'}}),
                         # smiple symmetric bonding with weight
@@ -298,14 +295,12 @@ def test_read_cgsmiles(smile, nodes, charges, edges, orders):
                          "[#TC4][#OT1][#CD1]",
                         {0: ["$1"], 2: ["$1"]},
                         None,
-                        None,
                         {'weight': {1: 0.5}}),
                         # smiple symmetric bonding with random
                         # keyword argument
                         ("[$][#TC4][#OT1;r=abc][#CD1][$]",
                          "[#TC4][#OT1][#CD1]",
                         {0: ["$1"], 2: ["$1"]},
-                        None,
                         None,
                         {'r': {1: 'abc'}}),
                         # smiple symmetric bonding with weight
@@ -314,13 +309,11 @@ def test_read_cgsmiles(smile, nodes, charges, edges, orders):
                          "CO[C]([H])[H]",
                         {0: ["$1"], 2: ["$1"]},
                         None,
-                        None,
                         {'weight': {2: 0.5, 3: 0.1, 4: 0.2}}),
                         # H atom with weight goes first
                         ("[H;0.3]C[$]O[C;0.5][$]",
                          "[H]CO[C]",
                         {1: ["$1"], 3: ["$1"]},
-                        None,
                         None,
                         {'weight': {0: 0.3, 3: 0.5}}),
                         # smiple symmetric bonding after branch
@@ -328,13 +321,11 @@ def test_read_cgsmiles(smile, nodes, charges, edges, orders):
                          "CC(CC)",
                         {0: ["$1"], 1: ["$1"]},
                         None,
-                        None,
                         None),
                         # smiple symmetric bonding after ring
                         ("[$]CC1[$]CCC1",
                          "CC1CCC1",
                         {0: ["$1"], 1: ["$1"]},
-                        None,
                         None,
                         None),
                         # clear order symbol
@@ -342,13 +333,11 @@ def test_read_cgsmiles(smile, nodes, charges, edges, orders):
                          "[CH]=[CH]",
                         {0: ["$a1"], 1: ["$c1"]},
                         None,
-                        None,
                         None),
                         # multiple non-one bonding l
                         ("CC=[$a]=[$b]CC",
                          "CCCC",
                         {1: ["$a2", "$b2"]},
-                        None,
                         None,
                         None),
                         # multiple non-one bonding l
@@ -356,13 +345,11 @@ def test_read_cgsmiles(smile, nodes, charges, edges, orders):
                          "CCCC",
                         {1: ["$a1", "$b2"]},
                         None,
-                        None,
                         None),
                         # smiple symmetric bonding with more than one name
                         ("[$1A]COC[$1A]",
                          "COC",
                         {0: ["$1A1"], 2: ["$1A1"]},
-                        None,
                         None,
                         None),
                         # smiple bonding multiletter atom
@@ -370,13 +357,11 @@ def test_read_cgsmiles(smile, nodes, charges, edges, orders):
                          "Clcc",
                         {1: ["$1"], 2: ["$1"]},
                         None,
-                        None,
                         None),
                         # simple symmetric but with explicit hydrogen
                         ("[$][CH2]O[CH2][$]",
                          "[CH2]O[CH2]",
                         {0: ["$1"], 2: ["$1"]},
-                        None,
                         None,
                         None),
                         # smiple symmetric bonding; multiple descript
@@ -384,13 +369,11 @@ def test_read_cgsmiles(smile, nodes, charges, edges, orders):
                          "COC",
                         {0: ["$1"], 2: ["$1", "$11"]},
                         None,
-                        None,
                         None),
                         # named different bonding descriptors
                         ("[$1]CCCC[$2]",
                          "CCCC",
                         {0: ["$11"], 3: ["$21"]},
-                        None,
                         None,
                         None),
                         # ring and bonding descriptors
@@ -398,13 +381,11 @@ def test_read_cgsmiles(smile, nodes, charges, edges, orders):
                          "CCC1CCCCC1",
                         {0: ["$11"], 1: ["$21"]},
                         None,
-                        None,
                         None),
                         # bonding descript. after branch
                         ("C(COC[$1])[$2]CCC[$3]",
                          "C(COC)CCC",
                         {0: ["$21"], 3: ["$11"], 6: ["$31"]},
-                        None,
                         None,
                         None),
                         # left rigth bonding desciptors
@@ -412,50 +393,42 @@ def test_read_cgsmiles(smile, nodes, charges, edges, orders):
                         "COC",
                         {0: [">1"], 2: ["<1"]},
                         None,
-                        None,
                         None),
                         # simple chirality in residue
-                        ("[>]C[C@](F)(B)N[<]",
+                        ("[>]C[C;x=R](F)(B)N[<]",
                         "C[C](F)(B)N",
                         {0: [">1"], 4: ["<1"]},
-                        {1: ('@', [])},
                         None,
-                        None),
+                        {'chiral': {1: 'R'}}),
                         # simple chirality inverse in residue
-                        ("[>]C[C@@](F)(B)N[<]",
+                        ("[>]C[C;x=S](F)(B)N[<]",
                         "C[C](F)(B)N",
                         {0: [">1"], 4: ["<1"]},
-                        {1: ('@@', [])},
                         None,
-                        None),
+                        {'chiral': {1: 'S'}}),
                         # \ fragment split
                         ("[>]CC(\F)=[<]",
                         "CC(F)",
                         {0: [">1"], 1: ["<2"]},
-                        None,
                         {2: (2, 1, '\\')},
                         None),
                         # / fragment split
                         ("[>]CC(/F)=[<]",
                         "CC(F)",
                         {0: [">1"], 1: ["<2"]},
-                        None,
                         {2: (2, 1, '/')},
                         None),
                         # both in one fragment
                         ("[>]CC(/F)=C(\F)C[<]",
                         "CC(F)=C(F)C",
                         {0: [">1"], 5: ["<1"]},
-                        None,
                         {2: (2, 1, '/'), 4: (4, 3, '\\')},
                         None),
 ))
-def test_strip_bonding_descriptors(big_smile, smile, bonding, rs, ez, attrs):
-    new_smile, new_bonding, rs_isomers, ez_isomers, attrs_out = strip_bonding_descriptors(big_smile)
+def test_strip_bonding_descriptors(big_smile, smile, bonding, ez, attrs):
+    new_smile, new_bonding, ez_isomers, attrs_out = strip_bonding_descriptors(big_smile)
     assert new_smile == smile
     assert new_bonding == bonding
-    if rs:
-        assert rs == rs_isomers
     if ez:
         assert ez == ez_isomers
     # here we check that the weights are correctly

--- a/cgsmiles/tests/test_molecule_resolve.py
+++ b/cgsmiles/tests/test_molecule_resolve.py
@@ -186,17 +186,17 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                          (1, 7), (5, 9), (5, 6), (7, 13), (7, 8),
                          (9, 11), (9, 10), (11, 13), (11, 12), (13, 14)], {}, {}, {}),
                          # simple chirality assigment with rings
-                         ("{[#GLC]}.{#GLC=C([C@@H]1[C@H]([C@@H]([C@H]([C@H](O1)O)O)O)O)O}",
+                         # (3R,4S,5S,6R)-6-(hydroxymethyl)oxane-2,3,4,5-tetrol (cyclic form)
+                         ("{[#GLC]}.{#GLC=[CH;x=R]([CH;x=S]1[CH;x=S]([C;x=R](C(C(O1)O)O)O)O)O}",
                          # 0 1 2 3
                          [('GLC', 'C C C C C C O O O O O O H H H H H H H H H H H H')],
                          'C C C C C C O O O O O O H H H H H H H H H H H H',
                          [(0, 1), (0, 11), (0, 12), (0, 13), (1, 2), (1, 6), (1, 14), (2, 3), (2, 10),
                           (2, 15), (3, 4), (3, 9), (3, 16), (4, 5), (4, 8), (4, 17), (5, 6), (5, 7), (5, 18),
                           (7, 19), (8, 20), (9, 21), (10, 22), (11, 23)],
-                         {1: (6, 14, 2, 0), 2: (1, 15, 3, 10), 3: (2, 16, 9, 4),
-                          4: (3, 17, 5, 8), 5: (4, 18, 6, 7)}, {}, {}),
+                         {0: 'R', 1: 'S', 2: 'S', 3: 'R'}, {}, {}),
                         # simple chirality assigment between fragments
-                        ("{[#A][#B][#C]}.{#A=O[>],#C=O[<],#B=[<]C[C@H][>]C(=O)OC}",
+                        ("{[#A][#B][#C]}.{#A=O[>],#C=O[<],#B=[<]C[CH;x=R][>]C(=O)OC}",
                         # 0 1 2 3
                         [('A', 'O H'), ('B', 'C C C O O C H H H H H H'),
                          ('C', 'O H')],
@@ -204,9 +204,9 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                         [(0, 1), (0, 2), (2, 3), (2, 4),
                          (2, 5), (5, 6), (5, 7), (7, 8), (7, 9), (9, 10), (10, 11), (10, 12),
                          (10, 13), (5, 14), (14, 15)],
-                        {3: (2, 10, 4, 14)}, {}, {}),
+                        {3: 'R'}, {}, {}),
                         # simple chirality assigment between fragments inv
-                        ("{[#A][#B][#C]}.{#A=O[>],#C=O[<],#B=[<]C[C@@H][>]C(=O)OC}",
+                        ("{[#A][#B][#C]}.{#A=O[>],#C=O[<],#B=[<]C[CH;x=S][>]C(=O)OC}",
                         # 0 1 2 3
                         [('A', 'O H'), ('B', 'C C C O O C H H H H H H'),
                          ('C', 'O H')],
@@ -214,7 +214,7 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                         [(0, 1), (0, 2), (2, 3), (2, 4),
                          (2, 5), (5, 6), (5, 7), (7, 8), (7, 9), (9, 10), (10, 11), (10, 12),
                          (10, 13), (5, 14), (14, 15)],
-                        {3: (2, 10, 14, 4)}, {}, {}),
+                        {3: 'S'}, {}, {}),
                         # smiple ez isomerism assigment between fragments inv
                         ("{[#A][#B]}.{#A=CC(/F)=[$],#B=[$]=C(\F)C}",
                         [('A', 'C C F H H H'), ('B', 'C F C H H H')],
@@ -309,7 +309,7 @@ def test_all_atom_resolve_molecule(smile, ref_frags, elements, ref_edges, chiral
 
     # check chirality
     if chiral:
-        chiral_assigned = nx.get_node_attributes(molecule, 'rs_isomer')
+        chiral_assigned = nx.get_node_attributes(molecule, 'chiral')
         assert chiral == chiral_assigned
     # check ez isomerism
     if ez:

--- a/cgsmiles/tests/test_write_cgsmiles.py
+++ b/cgsmiles/tests/test_write_cgsmiles.py
@@ -67,6 +67,7 @@ def test_write_cgsmiles(input_string):
     out_resolver =  MoleculeResolver.from_string(output_string)
     out_mol = out_resolver.molecule
     assertEqualGraphs(molecule, out_mol)
+    print("fragments")
     out_fragments = out_resolver.fragment_dicts
     assert len(fragment_dicts) == len(out_fragments)
     for frag_dict, frag_dict_out in zip(fragment_dicts, out_fragments):


### PR DESCRIPTION
Implements chirality as annotation. This PR also refactors the dialect a bit. Now types need to be provided explicitly, to be able to assign None as default. Attributes with None value are filtered out. It is a design choice but I kind of like the pysmiles convention in this regard. 