### PR TITLE
fix multi squash

### DIFF
--- a/cgsmiles/resolve.py
+++ b/cgsmiles/resolve.py
@@ -331,12 +331,14 @@ class MoleculeResolver:
         node.
         """
         bondings = nx.get_edge_attributes(self.molecule, 'bonding')
-        squashed = False
+        squashed = {}
         for edge, bonding in bondings.items():
             if not bonding[0].startswith('!'):
                 continue
             # let's squash two nodes
-            node_to_keep, node_to_remove = edge
+            node_to_keep = squashed.get(edge[0], edge[0])
+            node_to_remove = squashed.get(edge[1], edge[1])
+            squashed[node_to_remove] = node_to_keep
             self.molecule = nx.contracted_nodes(self.molecule,
                                                 node_to_keep,
                                                 node_to_remove,

--- a/cgsmiles/tests/test_molecule_resolve.py
+++ b/cgsmiles/tests/test_molecule_resolve.py
@@ -185,6 +185,13 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                         [(0, 1), (0, 2), (0, 3), (0, 4), (1, 5),
                          (1, 7), (5, 9), (5, 6), (7, 13), (7, 8),
                          (9, 11), (9, 10), (11, 13), (11, 12), (13, 14)], {}, {}, {}),
+                        # multiple squashes on one atom
+                        ("{[#A]([#B])[#B]}.{#A=OC[!][!],#B=[!]CC}",
+                        [('A', 'O H C H'), ('B', 'C H C H H H'), ('B', 'C H C H H H')],
+                        #0 1 2 3 4 5 6 7 8 9 10 11
+                        'O H C H C H H H C H H H',
+                        [(0, 1), (0, 2), (2, 3), (2, 4), (4, 5),
+                         (4, 6), (4, 7), (2, 8), (8, 9), (8, 10), (8, 11)], {}, {}, {}),
                          # simple chirality assigment with rings
                          # (3R,4S,5S,6R)-6-(hydroxymethyl)oxane-2,3,4,5-tetrol (cyclic form)
                          ("{[#GLC]}.{#GLC=[CH;x=R]([CH;x=S]1[CH;x=S]([C;x=R](C(C(O1)O)O)O)O)O}",


### PR DESCRIPTION
When doing multiple squashes on the same atom we need to keep track of which node get's squashed. We need this information because the squash bonding operator may refer to the wrong bond. 