### PR TITLE
Add matplotlib plotting to drawing tutorial

### DIFF
--- a/docs/source/gettingstarted/tutorials/drawing.rst
+++ b/docs/source/gettingstarted/tutorials/drawing.rst
@@ -16,6 +16,7 @@ Martini 3 Benzene.
 
     import cgsmiles
     from cgsmiles.drawing import draw_molecule
+    import matplotlib.pyplot as plt
 
     # Martini 3 Benzene
     cgsmiles_str = "{[#TC5]1[#TC5][#TC5]1}.{#TC5=[$]cc[$]}"
@@ -25,6 +26,9 @@ Martini 3 Benzene.
 
     # Draw molecule at different resolutions
     ax, pos = draw_molecule(mol_graph)
+
+    # Display the drawing
+    plt.show()
 
 By setting ``cg_mapping=False`` only the atomic resolution molecule is drawn.
 Sometimes it is handy to not draw all the hydrogen atoms of a molecule. To do so
@@ -38,6 +42,7 @@ illustrates this for poly(ethylene) glycol.
     import networkx as nx
     import cgsmiles
     from cgsmiles.drawing import draw_molecule
+    import matplotlib.pyplot as plt
 
     # PEO Polymer
     cgsmiles_str = "{[#PEO]|10}.{#PEO=[$]COC[$]}"
@@ -61,6 +66,9 @@ illustrates this for poly(ethylene) glycol.
     # Draw molecule at different resolutions
     ax, pos = draw_molecule(mol_graph, labels=labels, scale=1)
     ax.set_frame_on('True')
+
+    # Display the drawing
+    plt.show()
 
 Likely, you will see that not the entire molecule fits in the bounding box as
 indicated by the frame. The reason is that the drawing function does not
@@ -88,31 +96,35 @@ can see a simple example below.
 
 .. code:: python
 
-  import cgsmiles
-  from cgsmiles.drawing import draw_molecule
-
-  # let's have two panels for each molecule
-  fig, axes = plt.subplots(1,2, figsize=(6, 6))
-
-  # trans butene
-  cgsmiles_str_tans = "{[#A][#B]}.{#A=C\C=[$],#B=[$]=C\C}"
-
-  # cis butene
-  cgsmiles_str_cis = "{[#A][#B]}.{#A=C\C=[$],#B=[$]=C/C}"
-
-  # Resolve molecule into networkx graphs
-  for ax, cgstr in zip(axes, [cgsmiles_str_tans, cgsmiles_str_cis]):
-      res_graph, mol_graph = cgsmiles.MoleculeResolver.from_string(cgstr).resolve()
-      pysmiles.remove_explicit_hydrogens(mol_graph)
-
-      # Now we generate the node labels
-      labels = {}
-      for node in mol_graph.nodes:
-        hcount =  mol_graph.nodes[node].get('hcount', 0)
-        label = mol_graph.nodes[node].get('element', '*')
-        if hcount > 0:
-            label = label + f"H{hcount}"
-        labels[node] = label
-
-      # Draw molecule at different resolutions
-      ax, pos = draw_molecule(mol_graph, ax=ax, labels=labels)
+   import cgsmiles
+   from cgsmiles.drawing import draw_molecule
+   import matplotlib.pyplot as plt
+   
+   # let's have two panels for each molecule
+   fig, axes = plt.subplots(1,2, figsize=(6, 6))
+   
+   # trans butene
+   cgsmiles_str_tans = "{[#A][#B]}.{#A=C\C=[$],#B=[$]=C\C}"
+   
+   # cis butene
+   cgsmiles_str_cis = "{[#A][#B]}.{#A=C\C=[$],#B=[$]=C/C}"
+   
+   # Resolve molecule into networkx graphs
+   for ax, cgstr in zip(axes, [cgsmiles_str_tans, cgsmiles_str_cis]):
+       res_graph, mol_graph = cgsmiles.MoleculeResolver.from_string(cgstr).resolve()
+       pysmiles.remove_explicit_hydrogens(mol_graph)
+   
+       # Now we generate the node labels
+       labels = {}
+       for node in mol_graph.nodes:
+         hcount =  mol_graph.nodes[node].get('hcount', 0)
+         label = mol_graph.nodes[node].get('element', '*')
+         if hcount > 0:
+             label = label + f"H{hcount}"
+         labels[node] = label
+   
+       # Draw molecule at different resolutions
+       ax, pos = draw_molecule(mol_graph, ax=ax, labels=labels)
+   
+       # Display the drawing
+       plt.show()


### PR DESCRIPTION
The tutorial implicitly assumes one would you `plt.show()` to display the drawing but I think it's best to explicitly include the couple of lines needed - hence this PR.