### PR TITLE
More robust drawing tutorial

### DIFF
--- a/docs/source/gettingstarted/tutorials/drawing.rst
+++ b/docs/source/gettingstarted/tutorials/drawing.rst
@@ -25,7 +25,8 @@ Martini 3 Benzene.
     res_graph, mol_graph = cgsmiles.MoleculeResolver.from_string(cgsmiles_str).resolve()
 
     # Draw molecule at different resolutions
-    ax, pos = draw_molecule(mol_graph)
+    fig, ax = plt.subplots(1, 1)
+    draw_molecule(mol_graph, ax=ax)
 
     # Display the drawing
     plt.show()
@@ -64,7 +65,8 @@ illustrates this for poly(ethylene) glycol.
         labels[node] = label
 
     # Draw molecule at different resolutions
-    ax, pos = draw_molecule(mol_graph, labels=labels, scale=1)
+    fig, ax = plt.subplots(1, 1)
+    draw_molecule(mol_graph, ax=ax, labels=labels, scale=1)
     ax.set_frame_on('True')
 
     # Display the drawing


### PR DESCRIPTION
Implementing the visualization tutorials in a script and running it via the terminal, I'd run into this problem:

![NAPH_wrong](https://github.com/user-attachments/assets/9f95565c-3358-47c3-8987-39227b4ed115)

which should show like this:

![NAPH_OK](https://github.com/user-attachments/assets/7233f2f7-5278-4cf6-9523-0725925234e8)

This PR fixes this by making sure that one gets a new plot object everytime you run.


