### PR TITLE
Bugfix/fragids

### DIFF
--- a/cgsmiles/graph_utils.py
+++ b/cgsmiles/graph_utils.py
@@ -7,18 +7,22 @@ from collections import defaultdict
 import itertools
 import networkx as nx
 
-def merge_graphs(source_graph, target_graph, max_node=None):
+def merge_graphs(source_graph, target_graph, fragid=None, max_node=None):
     """
-    Add the atoms and the interactions of a molecule at the end of this
-    one.
-
-    Atom and residue index of the new atoms are offset to follow the last
-    atom of this molecule.
+    Merge the `target_graph` into `source_graph`. Atom and residue index
+    of the newly added nodes are offset to follow the last node of `source_graph`,
+    unless the fragid and/or max_node are explicitly provided.
 
     Parameters
     ----------
-    molecule: networkx.Graph
-        The molecule to merge at the end.
+    source_graph: networkx.Graph
+        the graph into which to merge
+    target_graph: networkx.Graph
+        the graph to be merged into source graph
+    fragid: int
+        the fragid to be used on all newly added nodes
+    max_node: int
+        the maxmimum node from which to start adding the new nodes
 
     Returns
     -------
@@ -43,7 +47,10 @@ def merge_graphs(source_graph, target_graph, max_node=None):
     for idx, node in enumerate(target_graph.nodes(), start=offset + 1):
         correspondence[node] = idx
         new_atom = copy.deepcopy(target_graph.nodes[node])
-        new_atom['fragid'] = [(new_atom.get('fragid', 0) + fragment_offset)]
+        if fragid:
+            new_atom['fragid'] = [fragid]
+        else:
+            new_atom['fragid'] = [(new_atom.get('fragid', 0) + fragment_offset)]
         # make sure to propagate the ez isomers
         if 'ez_isomer_atoms' in new_atom:
             new_atom['ez_isomer_atoms'] = (new_atom['ez_isomer_atoms'][0]+offset+1,

--- a/cgsmiles/resolve.py
+++ b/cgsmiles/resolve.py
@@ -287,7 +287,7 @@ class MoleculeResolver:
                 continue
 
             fragment = fragment_dict[fragname]
-            correspondence = merge_graphs(self.molecule, fragment)
+            correspondence = merge_graphs(self.molecule, fragment, fragid=meta_node)
 
             graph_frag = nx.Graph()
 

--- a/cgsmiles/tests/test_molecule_resolve.py
+++ b/cgsmiles/tests/test_molecule_resolve.py
@@ -266,6 +266,16 @@ def test_match_bonding_descriptors(bonds_source, bonds_target, edge, btypes):
                         # test skip virtual nodes
                         ("{[#SP4]1.2[#SP4].3[#SP1r]1.[#TC4]23}.{#SP4=OC[$]C[$]O,#SP1r=[$]OC[$]CO}",
                         [('SP4', 'O C C O H H H H'), ('SP4', 'O C C O H H H H'),
+                         ('SP1r', 'O C C O H H H H'), ('TC4', '')],
+                        'O C C O H H H H O C C O H H H H O C C O H H H H',
+                        [(0, 1), (0, 4), (1, 2), (1, 9), (1, 5), (2, 3), (2, 16), (2, 6),
+                         (3, 7), (8, 9), (8, 12), (9, 10), (9, 13), (10, 11), (10, 17),
+                         (10, 14), (11, 15), (16, 17), (17, 18), (17, 20), (18, 19),
+                         (18, 21), (18, 22), (19, 23)],
+                        {},{}, {}),
+                        # test skip virtual nodes with VS in the middle
+                        ("{[#SP4]1.2[#SP4].([#TC4].2.3)[#SP1r]1.3}.{#SP4=OC[$]C[$]O,#SP1r=[$]OC[$]CO}",
+                        [('SP4', 'O C C O H H H H'), ('SP4', 'O C C O H H H H'), ('TC4', ''),
                          ('SP1r', 'O C C O H H H H')],
                         'O C C O H H H H O C C O H H H H O C C O H H H H',
                         [(0, 1), (0, 4), (1, 2), (1, 9), (1, 5), (2, 3), (2, 16), (2, 6),


### PR DESCRIPTION
Interestingly, the handling of virtual sides was incorrect. In the previous version, they would only be skipped when at the end of the CGsmiles string. When in the middle, for example, the `merge_graphs` function would incorrectly assign the atoms of the following bead to the VS. The test did not cover it because the VS was at the end, where the counting error goes unnoticed. 