### PR TITLE
fix coveralls "build already closed" error in the build matrix

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -34,6 +34,19 @@ jobs:
       run:  pytest --cov cgsmiles --cov-report=xml
     - name: Coveralls
       uses: coverallsapp/github-action@v2
+      with:
+        flag-name: python-${{ matrix.py_version }}
+        parallel: true
+
+  coveralls-finished:
+    needs: build
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+    - name: Close parallel build
+      uses: coverallsapp/github-action@v2
+      with:
+        parallel-finished: true
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The Coveralls upload step was added to the build job's Python-version matrix (5 parallel jobs) without parallel mode, so each job posted as if it were the entire build. The first upload to land closed the build immediately, and every later matrix job's upload then failed with "Can't add a job to a build that is already closed."

Mark each matrix job's upload as parallel (with a per-version flag-name), and add a coveralls-finished job that runs after the whole matrix completes to close the build once, per Coveralls' own parallel-builds docs (docs.coveralls.io/parallel-builds).